### PR TITLE
fix: pass installation key when getting external sites

### DIFF
--- a/src/commands/force/package/beta/install.ts
+++ b/src/commands/force/package/beta/install.ts
@@ -178,7 +178,7 @@ export class Install extends SfdxCommand {
   }
 
   private async confirmExternalSites(request: PackageInstallCreateRequest, noPrompt: boolean): Promise<void> {
-    const extSites = await this.pkg.getExternalSites(request.SubscriberPackageVersionKey);
+    const extSites = await this.pkg.getExternalSites(request.SubscriberPackageVersionKey, request.Password);
     if (extSites) {
       let enableRss = true;
       if (!noPrompt) {

--- a/test/commands/force/package/install.test.ts
+++ b/test/commands/force/package/install.test.ts
@@ -395,6 +395,25 @@ describe('force:package:install', () => {
       expect(result).to.deep.equal(pkgInstallRequest);
     });
 
+    it('should NOT confirm external sites with --noprompt flag and installation key', async () => {
+      const installationkey = '1234abcd';
+      const expectedCreateRequest = Object.assign({}, pkgInstallCreateRequest, {
+        EnableRss: true,
+        Password: installationkey,
+      });
+      getExternalSitesStub.resolves(extSites);
+      installStub.resolves(pkgInstallRequest);
+
+      const result = await runCmd(['-p', '04t6A000002zgKSQAY', '--noprompt', '-k', installationkey], true);
+
+      expect(getExternalSitesStub.calledOnce).to.be.true;
+      expect(getExternalSitesStub.args[0][0]).to.equal(pkgInstallCreateRequest.SubscriberPackageVersionKey);
+      expect(getExternalSitesStub.args[0][1]).to.equal(installationkey);
+      expect(uxConfirmStub.calledOnce).to.be.false;
+      expect(installStub.args[0][0]).to.deep.equal(expectedCreateRequest);
+      expect(result).to.deep.equal(pkgInstallRequest);
+    });
+
     it('should confirm external sites when NO --noprompt flag (yes answer)', async () => {
       const expectedCreateRequest = Object.assign({}, pkgInstallCreateRequest, { EnableRss: true });
       getExternalSitesStub.resolves(extSites);


### PR DESCRIPTION
### What does this PR do?
Passes the installation key to `Package.getExternalSites()` and adds a unit test to ensure it's passed.

### What issues does this PR fix or reference?
@W-0@