### PR TITLE
edit messages so that CLI Reference command generator doesn't fail

### DIFF
--- a/messages/package_create.md
+++ b/messages/package_create.md
@@ -8,12 +8,12 @@ If you don’t have a namespace defined in your sfdx-project.json file, use --no
 
 Your --name value must be unique within your namespace.
 
+Run 'sfdx force:package:list' to list all packages in the Dev Hub org.
+
 # examples
 
 $ sfdx force:package:create -n YourPackageName -t Unlocked -r force-app
 $ sfdx force:package:create -n YourPackageName -d "Your Package Descripton" -t Unlocked -r force-app
-
-Run 'sfdx force:package:list' to list all packages in the Dev Hub org.
 
 # name
 

--- a/messages/package_uninstall.md
+++ b/messages/package_uninstall.md
@@ -4,15 +4,15 @@ uninstall a second-generation package from the target org
 
 Specify the package ID for a second-generation package.
 
+To list the org’s installed packages, run "sfdx force:package:beta:installed:list".
+
+To uninstall a first-generation package, from Setup, enter Installed Packages in the Quick Find box, then select Installed Packages.
+
 # examples
 
 $ sfdx force:package:beta:uninstall -p 04t... -u me@example.com
 $ sfdx force:package:beta:uninstall -p undesirable_package_alias
 $ sfdx force:package:beta:uninstall -p "Undesirable Package Alias"
-
-To list the org’s installed packages, run "sfdx force:package:beta:installed:list".
-
-To uninstall a first-generation package, from Setup, enter Installed Packages in the Quick Find box, then select Installed Packages.
 
 # id
 

--- a/messages/package_update.md
+++ b/messages/package_update.md
@@ -4,12 +4,12 @@ update package details
 
 Specify a new value for each option you want to update.
 
+Run "sfdx force:package:list" to list all packages in the Dev Hub org.
+
 # examples
 
 $ sfdx force:package:update -p "Your Package Alias" -n "New Package Name"
 $ sfdx force:package:update -p 0Ho... -d "New Package Description"
-
-Run "sfdx force:package:list" to list all packages in the Dev Hub org.
 
 # package
 

--- a/messages/package_version_create_report.md
+++ b/messages/package_version_create_report.md
@@ -4,12 +4,12 @@ retrieve details about a package version creation request
 
 Specify the request ID for which you want to view details. If applicable, the command displays errors related to the request.
 
+To show all requests in the org, run "sfdx force:package:version:create:list".
+
 # examples
 
 $ sfdx force:package:version:create:report -i 08c...
 $ sfdx force:package:version:create:report -i 08c... -v devhub@example.com
-
-To show all requests in the org, run "sfdx force:package:version:create:list".
 
 # requestId
 

--- a/messages/package_version_report.md
+++ b/messages/package_version_report.md
@@ -2,12 +2,12 @@
 
 retrieve details about a package version in the Dev Hub org
 
+To update package version values, run "sfdx force:package:version:update".
+
 # examples
 
 $ sfdx force:package:version:report -p 04t...
 $ sfdx force:package:version:report -p "Your Package Alias"
-
-To update package version values, run "sfdx force:package:version:update".
 
 # package
 

--- a/messages/package_version_update.md
+++ b/messages/package_version_update.md
@@ -4,13 +4,13 @@ update a package version
 
 Specify a new value for each option you want to update.
 
+To display details about a package version, run "sfdx force:package:version:report".
+
 # examples
 
 $ sfdx force:package:version:update -p "Your Package Alias" -k password123
 $ sfdx force:package:version:update -p 04t... -b main -t 'Release 1.0.7'
 $ sfdx force:package:version:update -p 04t... -e "New Package Version Description"
-
-To display details about a package version, run "sfdx force:package:version:report".
 
 # package
 


### PR DESCRIPTION
### What does this PR do?

The CLI Command generator is failing because there are non-examples in the ##examples section.  So I moved 'em up to the description.

NOTE that I will be doing a more thorough review of the --help messages in this new plugin.  I have a feeling some long descriptions have been lost... But for now I just want to get the command generator working.  I'll do the additional review before these new commands go GA.

### What issues does this PR fix or reference?
@ W-11653749@