### PR TITLE
fix: keep only examples in #examples section

### DIFF
--- a/messages/package2_create.md
+++ b/messages/package2_create.md
@@ -12,11 +12,11 @@ First, use this command to create a second-generation package. Then create a pac
 
 Your --name value must be unique within your namespace.
 
+Run 'sfdx force:package2:list' to list all second-generation packages in the Dev Hub org.
+
 # examples
 
 $ sfdx force:package2:create -n PackageName -d 'My New Package' -o Unlocked
-
-Run 'sfdx force:package2:list' to list all second-generation packages in the Dev Hub org.
 
 # name
 

--- a/messages/package2_update.md
+++ b/messages/package2_update.md
@@ -10,12 +10,12 @@ Updates a second-generation package.
 
 Specify a new value for each option you want to update.
 
+Run 'sfdx force:package2:list' to list all second-generation packages in the Dev Hub org.
+
 # examples
 
 $ sfdx force:package2:update --package2id 0Ho... --name 'AAnalytics'
 $ sfdx force:package2:update -i 0Ho... -d 'Advanced Analytics'
-
-Run 'sfdx force:package2:list' to list all second-generation packages in the Dev Hub org.
 
 # id
 

--- a/messages/package2_version_create_get.md
+++ b/messages/package2_version_create_get.md
@@ -10,11 +10,11 @@ Retrieves a second-generation package version creation request in the Dev Hub or
 
 Specify the request ID for which you want to view details. If applicable, the command displays errors related to the request.
 
+To show all requests in the org, run "sfdx force:package2:version:create:list".
+
 # examples
 
 $ sfdx force:package2:version:create:get --package2createrequestid 08c...
-
-To show all requests in the org, run "sfdx force:package2:version:create:list".
 
 # requestId
 

--- a/messages/package2_version_get.md
+++ b/messages/package2_version_get.md
@@ -6,6 +6,8 @@ retrieve a package version in the Dev Hub org
 
 Retrieves a package version in the Dev Hub org.
 
+To update package version values, run "sfdx force:package2:version:update".
+
 # examples
 
 $ sfdx force:package2:version:get --package2versionid 05i...

--- a/messages/package2_version_update.md
+++ b/messages/package2_version_update.md
@@ -10,12 +10,12 @@ Updates a second-generation package version in the Dev Hub org.
 
 Specify a new value for each option you want to update.
 
+To display details about a package2 version, run "sfdx force:package2:version:get".
+
 # examples
 
 $ sfdx force:package2:version:update --package2versionid 05i... --setasreleased
 $ sfdx force:package2:version:update -i 05i... -b master -t 'Release 1.0.7'
-
-To display details about a package2 version, run "sfdx force:package2:version:get".
 
 # id
 


### PR DESCRIPTION
### What does this PR do?

Moves non-example content from # examples section to #help or #description

### What issues does this PR fix or reference?
@W-11597858@