### PR TITLE
ci: env at workflow level

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
     branches-ignore: [main]
   workflow_dispatch:
 
+env:
+  ONEGP_TESTKIT_AUTH_URL: ${{secrets.ONEGP_TESTKIT_AUTH_URL}}
+
 jobs:
   unit-tests:
     uses: salesforcecli/github-workflows/.github/workflows/unitTest.yml@main


### PR DESCRIPTION
### What does this PR do?
inject special nut env secret into workflow env (since nut job isn't otherwise aware of it)