### PR TITLE
fix: enumerate and format server errors better

### DIFF
--- a/messages/package_version_create.md
+++ b/messages/package_version_create.md
@@ -301,9 +301,9 @@ Can’t create package version. Check your sfdx-project.json file and set includ
 
 The directory [%s] doesn’t exist in the current directory.
 
-# unknownError
+# multipleErrors
 
-Package version creation failed with unknown error.
+Multiple errors occurred:
 
 # malformedUrl
 

--- a/src/commands/force/package/beta/version/create.ts
+++ b/src/commands/force/package/beta/version/create.ts
@@ -192,7 +192,7 @@ export class PackageVersionCreateCommand extends SfdxCommand {
     this.ux.stopSpinner(messages.getMessage('packageVersionCreateFinalStatus', [result.Status]));
     switch (result.Status) {
       case 'Error':
-        throw messages.createError('unknownError', [
+        throw messages.createError('multipleErrors', [
           result.Error.map((e: string, i) => `${os.EOL}(${i + 1}) ${e}`).join(''),
         ]);
       case 'Success':

--- a/src/commands/force/package/beta/version/create.ts
+++ b/src/commands/force/package/beta/version/create.ts
@@ -9,7 +9,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
-import { Duration, camelCaseToTitleCase } from '@salesforce/kit';
+import { camelCaseToTitleCase, Duration } from '@salesforce/kit';
 import { Lifecycle, Messages } from '@salesforce/core';
 import {
   INSTALL_URL_BASE,
@@ -192,7 +192,9 @@ export class PackageVersionCreateCommand extends SfdxCommand {
     this.ux.stopSpinner(messages.getMessage('packageVersionCreateFinalStatus', [result.Status]));
     switch (result.Status) {
       case 'Error':
-        throw messages.createError('unknownError', [result.Error.join('\n')]);
+        throw messages.createError('unknownError', [
+          result.Error.map((e: string, i) => `${os.EOL}(${i + 1}) ${e}`).join(''),
+        ]);
       case 'Success':
         this.ux.log(
           messages.getMessage(result.Status, [

--- a/test/commands/force/package/packageVersionCreate.test.ts
+++ b/test/commands/force/package/packageVersionCreate.test.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import * as os from 'os';
 import { Org, SfProject } from '@salesforce/core';
 import { TestContext } from '@salesforce/core/lib/testSetup';
 import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
@@ -101,7 +102,7 @@ describe('force:package:version:report - tests', () => {
       });
       expect(uxLogStub.callCount).to.equal(1);
       expect(uxLogStub.args[0]).to.deep.equal([
-        'Successfully created the package version [08c3i000000fylgAAA]. Subscriber Package Version Id: 04t3i000002eya2AAA\nPackage Installation URL: https://login.salesforce.com/packaging/installPackage.apexp?p0=04t3i000002eya2AAA\nAs an alternative, you can use the "sfdx force:package:install" command.',
+        `Successfully created the package version [08c3i000000fylgAAA]. Subscriber Package Version Id: 04t3i000002eya2AAA${os.EOL}Package Installation URL: https://login.salesforce.com/packaging/installPackage.apexp?p0=04t3i000002eya2AAA${os.EOL}As an alternative, you can use the "sfdx force:package:install" command.`,
       ]);
     });
 
@@ -113,10 +114,7 @@ describe('force:package:version:report - tests', () => {
         assert.fail('the above should throw multiple errors');
       } catch (e) {
         expect((e as Error).message).to.equal(
-          'Package version creation failed with unknown error. \n' +
-            '(1) PropertyController: Invalid type: Schema.Property__c\n' +
-            '(2) SampleDataController: Invalid type: Schema.Property__c\n' +
-            '(3) SampleDataController: Invalid type: Schema.Broker__c'
+          `Package version creation failed with unknown error. ${os.EOL}(1) PropertyController: Invalid type: Schema.Property__c${os.EOL}(2) SampleDataController: Invalid type: Schema.Property__c${os.EOL}(3) SampleDataController: Invalid type: Schema.Broker__c`
         );
       }
     });

--- a/test/commands/force/package/packageVersionCreate.test.ts
+++ b/test/commands/force/package/packageVersionCreate.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { Org, SfProject } from '@salesforce/core';
+import { TestContext } from '@salesforce/core/lib/testSetup';
+import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
+import { Config } from '@oclif/core';
+import { assert, expect } from 'chai';
+import { PackageVersion, PackageVersionCreateRequestResult, PackagingSObjects } from '@salesforce/packaging';
+import { PackageVersionCreateCommand } from '../../../../src/commands/force/package/beta/version/create';
+import Package2VersionStatus = PackagingSObjects.Package2VersionStatus;
+
+describe('force:package:version:report - tests', () => {
+  const $$ = new TestContext();
+  let createStub = $$.SANDBOX.stub(PackageVersion, 'create');
+  let uxLogStub: sinon.SinonStub;
+  const oclifConfigStub = fromStub(stubInterface<Config>($$.SANDBOX));
+
+  const pkgVersionCreateErrorResult: PackageVersionCreateRequestResult = {
+    Id: '08c3i000000fylXXXX',
+    Status: Package2VersionStatus.error,
+    Package2Id: '0Ho3i000000TNHXXXX',
+    Package2VersionId: null,
+    SubscriberPackageVersionId: null,
+    Tag: null,
+    Branch: null,
+    Error: [
+      'PropertyController: Invalid type: Schema.Property__c',
+      'SampleDataController: Invalid type: Schema.Property__c',
+      'SampleDataController: Invalid type: Schema.Broker__c',
+    ],
+    CreatedDate: '2022-11-03 09:21',
+    HasMetadataRemoved: null,
+    CreatedBy: '0053i000001ZIyXXXX',
+  };
+  const pkgVersionCreateSuccessResult: PackageVersionCreateRequestResult = {
+    Id: '08c3i000000fylgAAA',
+    Status: Package2VersionStatus.success,
+    Package2Id: '0Ho3i000000TNHYCA4',
+    Package2VersionId: '05i3i000000fxw1AAA',
+    SubscriberPackageVersionId: '04t3i000002eya2AAA',
+    Tag: null,
+    Branch: null,
+    Error: [],
+    CreatedDate: '2022-11-03 09:46',
+    HasMetadataRemoved: false,
+    CreatedBy: '0053i000001ZIyGAAW',
+  };
+
+  class TestCommand extends PackageVersionCreateCommand {
+    public async runIt() {
+      await this.init();
+      uxLogStub = stubMethod($$.SANDBOX, this.ux, 'log');
+      return this.run();
+    }
+
+    public setProject(project: SfProject) {
+      this.project = project;
+    }
+
+    public setHubOrg(org: Org) {
+      this.hubOrg = org;
+    }
+  }
+
+  const runCmd = async (params: string[]) => {
+    const cmd = new TestCommand(params, oclifConfigStub);
+    stubMethod($$.SANDBOX, cmd, 'assignOrg').callsFake(() => {
+      const orgStub = fromStub(
+        stubInterface<Org>($$.SANDBOX, {
+          getUsername: () => 'test@user.com',
+          getConnection: () => ({}),
+        })
+      );
+      cmd.setHubOrg(orgStub);
+    });
+    cmd.setProject(SfProject.getInstance());
+
+    return cmd.runIt();
+  };
+
+  describe('force:package:version:create', () => {
+    it('should create a new package version', async () => {
+      createStub.resolves(pkgVersionCreateSuccessResult);
+      const res = await runCmd(['-p', '05i3i000000Gmj6XXX', '-v', 'test@hub.org', '-x']);
+      expect(res).to.deep.equal({
+        Branch: null,
+        CreatedBy: '0053i000001ZIyGAAW',
+        CreatedDate: '2022-11-03 09:46',
+        Error: [],
+        HasMetadataRemoved: false,
+        Id: '08c3i000000fylgAAA',
+        Package2Id: '0Ho3i000000TNHYCA4',
+        Package2VersionId: '05i3i000000fxw1AAA',
+        Status: 'Success',
+        SubscriberPackageVersionId: '04t3i000002eya2AAA',
+        Tag: null,
+      });
+      expect(uxLogStub.callCount).to.equal(1);
+      expect(uxLogStub.args[0]).to.deep.equal([
+        'Successfully created the package version [08c3i000000fylgAAA]. Subscriber Package Version Id: 04t3i000002eya2AAA\nPackage Installation URL: https://login.salesforce.com/packaging/installPackage.apexp?p0=04t3i000002eya2AAA\nAs an alternative, you can use the "sfdx force:package:install" command.',
+      ]);
+    });
+
+    it('should report multiple errors', async () => {
+      createStub = $$.SANDBOX.stub(PackageVersion, 'create');
+      createStub.resolves(pkgVersionCreateErrorResult);
+      try {
+        await runCmd(['-p', '05i3i000000Gmj6XXX', '-v', 'test@hub.org', '-x']);
+        assert.fail('the above should throw multiple errors');
+      } catch (e) {
+        expect((e as Error).message).to.equal(
+          'Package version creation failed with unknown error. \n' +
+            '(1) PropertyController: Invalid type: Schema.Property__c\n' +
+            '(2) SampleDataController: Invalid type: Schema.Property__c\n' +
+            '(3) SampleDataController: Invalid type: Schema.Broker__c'
+        );
+      }
+    });
+  });
+});

--- a/test/commands/force/package/packageVersionCreate.test.ts
+++ b/test/commands/force/package/packageVersionCreate.test.ts
@@ -114,7 +114,7 @@ describe('force:package:version:report - tests', () => {
         assert.fail('the above should throw multiple errors');
       } catch (e) {
         expect((e as Error).message).to.equal(
-          `Package version creation failed with unknown error. ${os.EOL}(1) PropertyController: Invalid type: Schema.Property__c${os.EOL}(2) SampleDataController: Invalid type: Schema.Property__c${os.EOL}(3) SampleDataController: Invalid type: Schema.Broker__c`
+          `Multiple errors occurred: ${os.EOL}(1) PropertyController: Invalid type: Schema.Property__c${os.EOL}(2) SampleDataController: Invalid type: Schema.Property__c${os.EOL}(3) SampleDataController: Invalid type: Schema.Broker__c`
         );
       }
     });


### PR DESCRIPTION
### What does this PR do?

fixes the way errors are displayed in the terminal.
1. create a package
2. now change the path in `sfdx-project.json` to point only to classes (as an example)
3. try to create a new package version

BEFORE:
```
Package version creation failed with unknown error. My_Object__c.My_Text_Field__c: Entity 'My_Object__c' not found.

Admin: In field: field - no CustomObject named My_Object__c found
```

AFTER:
```
ERROR running force:package:version:create: Multiple errors occurred:
(1) Admin: In field: field - no CustomObject named My_Object__c found
(2) My_Object__c.My_Text_Field__c: Entity 'My_Object__c' not found.
```

### What issues does this PR fix or reference?
@W-11911836@