### PR TITLE
fix: bump packaging lib version to 0.1.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@salesforce/command": "^5.2.17",
     "@salesforce/core": "^3.31.15",
     "@salesforce/kit": "^1.7.0",
-    "@salesforce/packaging": "^0.1.13",
+    "@salesforce/packaging": "^0.1.17",
     "chalk": "^4.1.2",
     "tslib": "^2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,7 +1129,7 @@
     typedoc-plugin-external-module-name "~4.0.0"
     typescript "^4.1.3"
 
-"@salesforce/kit@^1.6.1", "@salesforce/kit@^1.7.0":
+"@salesforce/kit@^1.6.1", "@salesforce/kit@^1.7.0", "@salesforce/kit@^1.7.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.7.1.tgz#2337ae354409726f1822f1b03a3d7073e84cd249"
   integrity sha512-XbLtEgMNBGZqtY/OldEru+LzASS3o37MZ6eNlSG19eAroGqFdlr4pzZUD/UaWSt6E0s0arj4IwAP5/hQLbrBZw==
@@ -1138,21 +1138,21 @@
     shx "^0.3.3"
     tslib "^2.2.0"
 
-"@salesforce/packaging@^0.1.13":
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-0.1.13.tgz#1ab532f9b9f6849b90ab3e468030363ada7555eb"
-  integrity sha512-ANaTlLIwkmPuVwIE+yTm+3iTxioQyqUb2VFQnTMXZpY37kKSwOnUpDM+PYyVpvyEjpDSdaaffKUBg5SXZspdsA==
+"@salesforce/packaging@^0.1.17":
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-0.1.17.tgz#9beea42cfe677b5eedfb0bac1b1502560cf17245"
+  integrity sha512-+dPkL197U03WSk241OJApLmwP0pr+AEsWjUe4LaEtgvQQp4LJ7jcP6mKISanIsZloK9LLRCiWXgRNpYODg3DpA==
   dependencies:
     "@oclif/core" "^1.19.1"
     "@salesforce/core" "^3.31.16"
-    "@salesforce/kit" "^1.7.0"
+    "@salesforce/kit" "^1.7.1"
     "@salesforce/schemas" "^1.1.3"
     "@salesforce/source-deploy-retrieve" "^7.0.1"
     "@salesforce/ts-types" "^1.5.21"
-    "@xmldom/xmldom" "^0.8.3"
+    "@xmldom/xmldom" "^0.8.5"
     debug "^4.3.4"
     globby "^11"
-    graphology "^0.25.0"
+    graphology "^0.25.1"
     graphology-traversal "^0.3.1"
     graphology-types "^0.24.5"
     js2xmlparser "^4.0.2"
@@ -1611,10 +1611,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@xmldom/xmldom@^0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.3.tgz#beaf980612532aa9a3004aff7e428943aeaa0711"
-  integrity sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==
+"@xmldom/xmldom@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.5.tgz#7f4b797cfda39355b512b4cfcc66b49b5d93d5f3"
+  integrity sha512-0dpjDLeCXYThL2YhqZcd/spuwoH+dmnFoND9ZxZkAYxp1IJUB2GP16ow2MJRsjVxy8j1Qv8BJRmN5GKnbDKCmQ==
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -4200,10 +4200,10 @@ graphology-utils@^2.0.0, graphology-utils@^2.4.2:
   resolved "https://registry.yarnpkg.com/graphology-utils/-/graphology-utils-2.5.2.tgz#4d30d6e567d27c01f105e1494af816742e8d2440"
   integrity sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==
 
-graphology@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/graphology/-/graphology-0.25.0.tgz#c2c85940210730e6a4e1bb9722bff99f38cff173"
-  integrity sha512-z0uwplYrhnQ2iwlqJZyd6CX0Xb9AIVNzK6N0MZouYCQBqMqz36s7YmEqqhuRj0ap7F/LX3dQjeWWRIkTkaGfEA==
+graphology@^0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/graphology/-/graphology-0.25.1.tgz#f92b86294782522d3898ce4480e4a577c0c2568a"
+  integrity sha512-yYA7BJCcXN2DrKNQQ9Qf22zBHm/yTbyBR71T1MYBbGtywNHsv0QZtk8zaR6zxNcp2hCCZayUkHp9DyMSZCpoxQ==
   dependencies:
     events "^3.3.0"
     obliterator "^2.0.2"


### PR DESCRIPTION
version 0.1.17 of the packaging lib bumps the xmldom version to a non-vulnerable version.

@W-11111111@
