### PR TITLE
fix: print errors when reporting on a new PV with errors

### DIFF
--- a/messages/package_version_create_report.md
+++ b/messages/package_version_create_report.md
@@ -18,3 +18,9 @@ package version creation request ID (starts with 08c)
 # requestIdLong
 
 The ID (starts with 08c) of the package version creation request you want to display.
+
+# truncatedErrors
+
+...
+
+To see all errors, run: sfdx force:data:soql:query -t -q "SELECT Message FROM Package2VersionCreateRequestError WHERE ParentRequest.Id='%s'" -u %s

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^3.2.11",
     "@oclif/plugin-version": "^1.1.2",
-    "@salesforce/cli-plugins-testkit": "^3.2.9",
+    "@salesforce/cli-plugins-testkit": "^3.2.12",
     "@salesforce/dev-config": "^3.1.0",
     "@salesforce/dev-scripts": "^3.1.0",
     "@salesforce/plugin-auth": "^2.2.21",

--- a/src/commands/force/package/beta/version/create/report.ts
+++ b/src/commands/force/package/beta/version/create/report.ts
@@ -31,13 +31,13 @@ export class PackageVersionCreateReportCommand extends SfdxCommand {
     }),
   };
 
-  public async run(): Promise<PackageVersionCreateRequestResult> {
+  public async run(): Promise<PackageVersionCreateRequestResult[]> {
     const result = await PackageVersion.getCreateStatus(
       this.flags.packagecreaterequestid as string,
       this.hubOrg.getConnection()
     );
     this.display(result);
-    return result;
+    return [result];
   }
 
   private display(record: PackageVersionCreateRequestResult): void {
@@ -89,5 +89,15 @@ export class PackageVersionCreateReportCommand extends SfdxCommand {
       key: { header: 'Name' },
       value: { header: 'Value' },
     });
+
+    if (record.Error?.length > 0) {
+      this.ux.log('');
+      const errors = [];
+      record.Error.forEach((error: string) => {
+        errors.push(`(${errors.length + 1}) ${error}`);
+      });
+      this.ux.styledHeader(chalk.red('Errors'));
+      this.ux.log(errors.join('\n'));
+    }
   }
 }

--- a/src/commands/force/package/beta/version/create/report.ts
+++ b/src/commands/force/package/beta/version/create/report.ts
@@ -18,6 +18,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_
 const pvclMessages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_version_create_list');
 const plMessages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_list');
 
+const ERROR_LIMIT = 12;
 export class PackageVersionCreateReportCommand extends SfdxCommand {
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
@@ -93,11 +94,22 @@ export class PackageVersionCreateReportCommand extends SfdxCommand {
     if (record.Error?.length > 0) {
       this.ux.log('');
       const errors = [];
-      record.Error.forEach((error: string) => {
+      record.Error.slice(0, ERROR_LIMIT).forEach((error: string) => {
         errors.push(`(${errors.length + 1}) ${error}`);
       });
       this.ux.styledHeader(chalk.red('Errors'));
       this.ux.log(errors.join('\n'));
+
+      // Check if errors were truncated.  If so, inform the user with
+      // instructions on how to retrieve the remaining errors.
+      if (record.Error.length > ERROR_LIMIT) {
+        this.ux.log(
+          messages.getMessage('truncatedErrors', [
+            this.flags.packagecreaterequestid as string,
+            this.hubOrg.getUsername(),
+          ])
+        );
+      }
     }
   }
 }

--- a/test/commands/force/package/packageVersion.nut.ts
+++ b/test/commands/force/package/packageVersion.nut.ts
@@ -102,12 +102,12 @@ describe('package:version:*', () => {
 
   describe('package:version:create:report', () => {
     it('reports on status (json)', () => {
-      const result = execCmd<PackageVersionCreateRequestResult>(
+      const result = execCmd<PackageVersionCreateRequestResult[]>(
         `force:package:beta:version:create:report -i ${packageVersionId} --json`,
         {
           ensureExitCode: 0,
         }
-      ).jsonOutput.result;
+      ).jsonOutput.result[0];
       expect(result.Id).to.match(/08c.{15}/);
       expect(result.Package2Id).to.match(/0Ho.{15}/);
       expect(result.Branch).to.equal('branch');
@@ -126,7 +126,7 @@ describe('package:version:*', () => {
     });
 
     it('reports on status (human)', () => {
-      const resultHuman = execCmd<PackageVersionCreateRequestResult>(
+      const resultHuman = execCmd<PackageVersionCreateRequestResult[]>(
         `force:package:beta:version:create:report -i ${packageVersionId}`,
         {
           ensureExitCode: 0,

--- a/test/commands/force/package/packageVersionCreate.test.ts
+++ b/test/commands/force/package/packageVersionCreate.test.ts
@@ -14,7 +14,7 @@ import { PackageVersion, PackageVersionCreateRequestResult, PackagingSObjects } 
 import { PackageVersionCreateCommand } from '../../../../src/commands/force/package/beta/version/create';
 import Package2VersionStatus = PackagingSObjects.Package2VersionStatus;
 
-describe('force:package:version:report - tests', () => {
+describe('force:package:version:create - tests', () => {
   const $$ = new TestContext();
   let createStub = $$.SANDBOX.stub(PackageVersion, 'create');
   let uxLogStub: sinon.SinonStub;

--- a/test/commands/force/package/packageVersionCreateReport.test.ts
+++ b/test/commands/force/package/packageVersionCreateReport.test.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { Org, SfProject } from '@salesforce/core';
+import { TestContext } from '@salesforce/core/lib/testSetup';
+import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
+import { Config } from '@oclif/core';
+import { expect } from 'chai';
+import { PackageVersion, PackageVersionCreateRequestResult, PackagingSObjects } from '@salesforce/packaging';
+import { PackageVersionCreateReportCommand } from '../../../../src/commands/force/package/beta/version/create/report';
+
+import Package2VersionStatus = PackagingSObjects.Package2VersionStatus;
+
+describe('force:package:version:create:report - tests', () => {
+  const $$ = new TestContext();
+  let createStatusStub = $$.SANDBOX.stub(PackageVersion, 'getCreateStatus');
+  let tableStub: sinon.SinonStub;
+  let styledHeaderStub: sinon.SinonStub;
+  let logStub: sinon.SinonStub;
+  const oclifConfigStub = fromStub(stubInterface<Config>($$.SANDBOX));
+
+  const pkgVersionCreateErrorResult: PackageVersionCreateRequestResult = {
+    Id: '08c3i000000fylXXXX',
+    Status: Package2VersionStatus.error,
+    Package2Id: '0Ho3i000000TNHXXXX',
+    Package2VersionId: null,
+    SubscriberPackageVersionId: null,
+    Tag: null,
+    Branch: null,
+    Error: [
+      'PropertyController: Invalid type: Schema.Property__c',
+      'SampleDataController: Invalid type: Schema.Property__c',
+      'SampleDataController: Invalid type: Schema.Broker__c',
+    ],
+    CreatedDate: '2022-11-03 09:21',
+    HasMetadataRemoved: null,
+    CreatedBy: '0053i000001ZIyXXXX',
+  };
+  const pkgVersionCreateSuccessResult: PackageVersionCreateRequestResult = {
+    Id: '08c3i000000fylgAAA',
+    Status: Package2VersionStatus.success,
+    Package2Id: '0Ho3i000000TNHYCA4',
+    Package2VersionId: '05i3i000000fxw1AAA',
+    SubscriberPackageVersionId: '04t3i000002eya2AAA',
+    Tag: null,
+    Branch: null,
+    Error: [],
+    CreatedDate: '2022-11-03 09:46',
+    HasMetadataRemoved: false,
+    CreatedBy: '0053i000001ZIyGAAW',
+  };
+
+  class TestCommand extends PackageVersionCreateReportCommand {
+    public async runIt() {
+      await this.init();
+      styledHeaderStub = stubMethod($$.SANDBOX, this.ux, 'styledHeader');
+      tableStub = stubMethod($$.SANDBOX, this.ux, 'table');
+      logStub = stubMethod($$.SANDBOX, this.ux, 'log');
+      return this.run();
+    }
+
+    public setProject(project: SfProject) {
+      this.project = project;
+    }
+
+    public setHubOrg(org: Org) {
+      this.hubOrg = org;
+    }
+  }
+
+  const runCmd = async (params: string[]) => {
+    const cmd = new TestCommand(params, oclifConfigStub);
+    stubMethod($$.SANDBOX, cmd, 'assignOrg').callsFake(() => {
+      const orgStub = fromStub(
+        stubInterface<Org>($$.SANDBOX, {
+          getUsername: () => 'test@user.com',
+          getConnection: () => ({}),
+        })
+      );
+      cmd.setHubOrg(orgStub);
+    });
+    cmd.setProject(SfProject.getInstance());
+
+    return cmd.runIt();
+  };
+
+  describe('force:package:version:create:report', () => {
+    it('should report on a new package version', async () => {
+      createStatusStub.resolves(pkgVersionCreateSuccessResult);
+      const res = await runCmd(['-i', '08c3i000000fyoVAAQ', '-v', 'test@hub.org']);
+
+      expect(res).to.deep.equal([
+        {
+          Branch: null,
+          CreatedBy: '0053i000001ZIyGAAW',
+          CreatedDate: '2022-11-03 09:46',
+          Error: [],
+          HasMetadataRemoved: false,
+          Id: '08c3i000000fylgAAA',
+          Package2Id: '0Ho3i000000TNHYCA4',
+          Package2VersionId: '05i3i000000fxw1AAA',
+          Status: 'Success',
+          SubscriberPackageVersionId: '04t3i000002eya2AAA',
+          Tag: null,
+        },
+      ]);
+      expect(tableStub.callCount).to.equal(1);
+      expect(styledHeaderStub.callCount).to.equal(1);
+    });
+
+    it('should report multiple errors', async () => {
+      createStatusStub = $$.SANDBOX.stub(PackageVersion, 'getCreateStatus');
+      createStatusStub.resolves(pkgVersionCreateErrorResult);
+
+      const result = await runCmd(['-i', '08c3i000000fyoVAAQ', '-v', 'test@hub.org']);
+
+      expect(logStub.callCount).to.equal(2);
+      expect(result[0]).to.deep.equal({
+        Branch: null,
+        CreatedBy: '0053i000001ZIyXXXX',
+        CreatedDate: '2022-11-03 09:21',
+        Error: [
+          'PropertyController: Invalid type: Schema.Property__c',
+          'SampleDataController: Invalid type: Schema.Property__c',
+          'SampleDataController: Invalid type: Schema.Broker__c',
+        ],
+        HasMetadataRemoved: null,
+        Id: '08c3i000000fylXXXX',
+        Package2Id: '0Ho3i000000TNHXXXX',
+        Package2VersionId: null,
+        Status: 'Error',
+        SubscriberPackageVersionId: null,
+        Tag: null,
+      });
+      expect(logStub.secondCall.args[0]).to.equal(
+        '(1) PropertyController: Invalid type: Schema.Property__c\n(2) SampleDataController: Invalid type: Schema.Property__c\n(3) SampleDataController: Invalid type: Schema.Broker__c'
+      );
+    });
+  });
+});

--- a/test/commands/force/package/packageVersionCreateReport.test.ts
+++ b/test/commands/force/package/packageVersionCreateReport.test.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import * as os from 'os';
 import { Org, SfProject } from '@salesforce/core';
 import { TestContext } from '@salesforce/core/lib/testSetup';
 import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
@@ -165,7 +166,7 @@ describe('force:package:version:create:report - tests', () => {
         '(11) SampleDataController: Invalid type: Schema.Property__c\n(12) SampleDataController: Invalid type: Schema.Broker__c'
       );
       expect(logStub.thirdCall.args[0]).to.deep.equal(
-        '...\n\nTo see all errors, run: sfdx force:data:soql:query -t -q "SELECT Message FROM Package2VersionCreateRequestError WHERE ParentRequest.Id=\'08c3i000000fyoVAAQ\'" -u test@hub.org'
+        `...${os.EOL}${os.EOL}To see all errors, run: sfdx force:data:soql:query -t -q "SELECT Message FROM Package2VersionCreateRequestError WHERE ParentRequest.Id='08c3i000000fyoVAAQ'" -u test@hub.org`
       );
     });
   });

--- a/test/commands/force/package/packageVersionCreateReport.test.ts
+++ b/test/commands/force/package/packageVersionCreateReport.test.ts
@@ -34,6 +34,17 @@ describe('force:package:version:create:report - tests', () => {
       'PropertyController: Invalid type: Schema.Property__c',
       'SampleDataController: Invalid type: Schema.Property__c',
       'SampleDataController: Invalid type: Schema.Broker__c',
+      'PropertyController: Invalid type: Schema.Property__c',
+      'SampleDataController: Invalid type: Schema.Property__c',
+      'SampleDataController: Invalid type: Schema.Broker__c',
+      'PropertyController: Invalid type: Schema.Property__c',
+      'SampleDataController: Invalid type: Schema.Property__c',
+      'SampleDataController: Invalid type: Schema.Broker__c',
+      'PropertyController: Invalid type: Schema.Property__c',
+      'SampleDataController: Invalid type: Schema.Property__c',
+      'SampleDataController: Invalid type: Schema.Broker__c',
+      'SampleDataController: Invalid type: Schema.Broker__c',
+      'SampleDataController: Invalid type: Schema.Broker__c',
     ],
     CreatedDate: '2022-11-03 09:21',
     HasMetadataRemoved: null,
@@ -117,14 +128,26 @@ describe('force:package:version:create:report - tests', () => {
 
       const result = await runCmd(['-i', '08c3i000000fyoVAAQ', '-v', 'test@hub.org']);
 
-      expect(logStub.callCount).to.equal(2);
+      expect(logStub.callCount).to.equal(3);
       expect(result[0]).to.deep.equal({
         Branch: null,
         CreatedBy: '0053i000001ZIyXXXX',
         CreatedDate: '2022-11-03 09:21',
+        // requires 12+ errors for error truncation message
         Error: [
           'PropertyController: Invalid type: Schema.Property__c',
           'SampleDataController: Invalid type: Schema.Property__c',
+          'SampleDataController: Invalid type: Schema.Broker__c',
+          'PropertyController: Invalid type: Schema.Property__c',
+          'SampleDataController: Invalid type: Schema.Property__c',
+          'SampleDataController: Invalid type: Schema.Broker__c',
+          'PropertyController: Invalid type: Schema.Property__c',
+          'SampleDataController: Invalid type: Schema.Property__c',
+          'SampleDataController: Invalid type: Schema.Broker__c',
+          'PropertyController: Invalid type: Schema.Property__c',
+          'SampleDataController: Invalid type: Schema.Property__c',
+          'SampleDataController: Invalid type: Schema.Broker__c',
+          'SampleDataController: Invalid type: Schema.Broker__c',
           'SampleDataController: Invalid type: Schema.Broker__c',
         ],
         HasMetadataRemoved: null,
@@ -135,8 +158,14 @@ describe('force:package:version:create:report - tests', () => {
         SubscriberPackageVersionId: null,
         Tag: null,
       });
-      expect(logStub.secondCall.args[0]).to.equal(
+      expect(logStub.secondCall.args[0]).to.include(
         '(1) PropertyController: Invalid type: Schema.Property__c\n(2) SampleDataController: Invalid type: Schema.Property__c\n(3) SampleDataController: Invalid type: Schema.Broker__c'
+      );
+      expect(logStub.secondCall.args[0]).to.include(
+        '(11) SampleDataController: Invalid type: Schema.Property__c\n(12) SampleDataController: Invalid type: Schema.Broker__c'
+      );
+      expect(logStub.thirdCall.args[0]).to.deep.equal(
+        '...\n\nTo see all errors, run: sfdx force:data:soql:query -t -q "SELECT Message FROM Package2VersionCreateRequestError WHERE ParentRequest.Id=\'08c3i000000fyoVAAQ\'" -u test@hub.org'
       );
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,12 +1040,12 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/cli-plugins-testkit@^3.2.9":
-  version "3.2.9"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-3.2.9.tgz#9bbfca80e9c95258b364b2e1d56173419da69ce8"
-  integrity sha512-GpJQ+toqDVOizyYnemtE11oWkNS6hMUxV7ht6nambzWCArIcK4aUVW7VIMxO6WnSLb66GZ9CbIHA1NEvWluydw==
+"@salesforce/cli-plugins-testkit@^3.2.12":
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-3.2.12.tgz#427e5d5f5aeda08b4e23248b323ae52b30e47b7e"
+  integrity sha512-66Jm7Kww6ay82+8nmooiyQtgGm45CHv/fptp64IIu8TTGSirhZbz251yM6qj+Y4yBb2ZpaUwY+mDnaQodgyNuQ==
   dependencies:
-    "@salesforce/core" "^3.32.1"
+    "@salesforce/core" "^3.32.6"
     "@salesforce/kit" "^1.8.0"
     "@salesforce/ts-types" "^1.5.21"
     "@types/shelljs" "^0.8.11"
@@ -1079,6 +1079,29 @@
     "@types/graceful-fs" "^4.1.5"
     "@types/semver" "^7.3.9"
     ajv "^8.11.0"
+    archiver "^5.3.0"
+    change-case "^4.1.2"
+    debug "^3.2.7"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    graceful-fs "^4.2.9"
+    js2xmlparser "^4.0.1"
+    jsforce "^2.0.0-beta.19"
+    jsonwebtoken "8.5.1"
+    ts-retry-promise "^0.7.0"
+
+"@salesforce/core@^3.32.6":
+  version "3.32.8"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.32.8.tgz#21d97f75645f8928cacb04497e91d8b203753130"
+  integrity sha512-q6vvpaBmw/cCSff+MX+aWYLVP44AzEI8oMLk14g/sY2O+Bij0ZBtil5bjhjkQqp3dJnkwKgaqpnvYPsrXSUN1g==
+  dependencies:
+    "@salesforce/bunyan" "^2.0.0"
+    "@salesforce/kit" "^1.8.0"
+    "@salesforce/schemas" "^1.4.0"
+    "@salesforce/ts-types" "^1.5.21"
+    "@types/graceful-fs" "^4.1.5"
+    "@types/semver" "^7.3.13"
+    ajv "^8.11.2"
     archiver "^5.3.0"
     change-case "^4.1.2"
     debug "^3.2.7"
@@ -1214,6 +1237,11 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.1.3.tgz#fce83f55c7557d47b9c814d5d02978ad734300b3"
   integrity sha512-XWohlOT2oQDqAJH00OXS3f2MGjkwZ6pr4emnnkHSQbg7UdGW0rvGpEnRKqBbDUfZ4K5YKSo9Gj216ZtaP3JLXg==
+
+"@salesforce/schemas@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.4.0.tgz#7dff427c8059895d8108176047aee600703c82d6"
+  integrity sha512-BJ25uphssN42Zy6kksheFHMTLiR98AAHe/Wxnv0T4dYxtrEbUjSXVAGKZqfewJPFXA4xB5gxC+rQZtfz6xKCFg==
 
 "@salesforce/source-deploy-retrieve@^7.0.1":
   version "7.1.0"
@@ -1566,7 +1594,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/semver@^7.3.12", "@types/semver@^7.3.9":
+"@types/semver@^7.3.12", "@types/semver@^7.3.13", "@types/semver@^7.3.9":
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
@@ -1777,6 +1805,16 @@ ajv@^8.0.1, ajv@^8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
   integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^8.11.2:
+  version "8.11.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.2.tgz#aecb20b50607acf2569b6382167b65a96008bb78"
+  integrity sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"


### PR DESCRIPTION
### What does this PR do?
`force:package:beta:version:create:report` now will include errors
```
 ➜  sfdx force:package:beta:version:create:report -i 08c3i000000fyoVAAQ 
=== Package Version Create Request

 Name                          Value              
 ───────────────────────────── ────────────────── 
 ID                            08c3i000000fyoVAAQ 

=== Errors

(1) Create_property: geocode_address (Action) - We can't find an action with the name and action type that you specified.
(2) dreamhouse: In field: apexClass - no ApexClass named PagedResult found
(3) PropertyController: Variable does not exist: result
(4) PropertyController: Variable does not exist: result
```

changes the `--json` output to match toolbelt, toolbelt has an array of results, we were just returning the result

```diff
 ➜  sfdx force:package:version:create:report -i 08c3i000000fyoVAAQ  --json
{
  "status": 0,
+  "result": [ {
- "result": {
      "Id": "08c3i000000fyoVAAQ",
```


### What issues does this PR fix or reference?
@W-11983124@
https://github.com/forcedotcom/cli/issues/1779