### PR TITLE
fix: pkg install polling timeout should display how to query the status

### DIFF
--- a/messages/package_install.md
+++ b/messages/package_install.md
@@ -136,6 +136,10 @@ Waiting %s minutes for package install to complete.
 
 %d minutes remaining until timeout. Publish status: %s
 
+# packageInstallPollingTimeout
+
+Polling timeout exceeded
+
 # availableForInstallation
 
 Available for installation

--- a/src/commands/force/package/beta/install.ts
+++ b/src/commands/force/package/beta/install.ts
@@ -216,7 +216,7 @@ export class Install extends SfdxCommand {
     return pkgInstallRequest;
   }
 
-  protected async finally(err: Optional<SfError>): Promise<void> {
+  protected async finally(err: Optional<Error>): Promise<void> {
     // Remove all the event listeners or they will still handle events
     Lifecycle.getInstance().removeAllListeners(PackageEvents.install.warning);
     Lifecycle.getInstance().removeAllListeners(PackageEvents.install.status);

--- a/src/commands/force/package/beta/install.ts
+++ b/src/commands/force/package/beta/install.ts
@@ -7,7 +7,7 @@
 
 import * as os from 'os';
 import { flags, FlagsConfig, SfdxCommand, UX } from '@salesforce/command';
-import { Connection, Lifecycle, Messages } from '@salesforce/core';
+import { Connection, Lifecycle, Messages, SfError } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
 import {
   PackageEvents,
@@ -190,20 +190,33 @@ export class Install extends SfdxCommand {
       );
     }
 
-    const pkgInstallRequest = await this.subscriberPackageVersion.install(request, installOptions);
-    this.ux.stopSpinner();
-    Install.parseStatus(
-      pkgInstallRequest,
-      this.ux,
-      messages,
-      this.org.getUsername(),
-      this.flags.package as Optional<string>
-    );
+    let pkgInstallRequest: PackageInstallRequest;
+    try {
+      pkgInstallRequest = await this.subscriberPackageVersion.install(request, installOptions);
+      this.ux.stopSpinner();
+    } catch (error: unknown) {
+      if (error instanceof SfError && error.data) {
+        pkgInstallRequest = error.data as PackageInstallRequest;
+        this.ux.stopSpinner(messages.getMessage('packageInstallPollingTimeout'));
+      } else {
+        throw error;
+      }
+    } finally {
+      if (pkgInstallRequest) {
+        Install.parseStatus(
+          pkgInstallRequest,
+          this.ux,
+          messages,
+          this.org.getUsername(),
+          this.flags.package as Optional<string>
+        );
+      }
+    }
 
     return pkgInstallRequest;
   }
 
-  protected async finally(err: Optional<Error>): Promise<void> {
+  protected async finally(err: Optional<SfError>): Promise<void> {
     // Remove all the event listeners or they will still handle events
     Lifecycle.getInstance().removeAllListeners(PackageEvents.install.warning);
     Lifecycle.getInstance().removeAllListeners(PackageEvents.install.status);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,8 @@
   "compilerOptions": {
     "outDir": "lib",
     "rootDir": "src",
-    "skipLibCheck": true
-  },
-  "paths": {
-    "@salesforce/core": ["node_modules/@salesforce/core"]
+    "skipLibCheck": true,
+    "baseUrl": "."
   },
   "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
### What does this PR do?
When a package install polling timeout occurs, the request ID and query command message is now displayed as it was in the salesforce-alm plugin version of the command.  Also, the command returns an exit code of 0 and the `PackageInstallRequest` json (also matching the salesforce-alm plugin version of the command).

### What issues does this PR fix or reference?
@W-12228879@