### PR TITLE
Sh/beta to prod

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2022, Salesforce.com, Inc.
+Copyright (c) 2023, Salesforce.com, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,6 +1,6 @@
 [
   {
-    "command": "force:package1:beta:version:create",
+    "command": "force:package1:version:create",
     "plugin": "@salesforce/plugin-packaging",
     "flags": [
       "apiversion",
@@ -17,28 +17,28 @@
       "version",
       "wait"
     ],
-    "alias": []
+    "alias": ["force:package1:beta:version:create"]
   },
   {
-    "command": "force:package1:beta:version:create:get",
+    "command": "force:package1:version:create:get",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "requestid", "targetusername"],
-    "alias": []
+    "alias": ["force:package1:beta:version:create:get"]
   },
   {
-    "command": "force:package1:beta:version:display",
+    "command": "force:package1:version:display",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "packageversionid", "targetusername"],
-    "alias": []
+    "alias": ["force:package1:beta:version:display"]
   },
   {
-    "command": "force:package1:beta:version:list",
+    "command": "force:package1:version:list",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "packageid", "targetusername"],
-    "alias": []
+    "alias": ["force:package1:beta:version:list"]
   },
   {
-    "command": "force:package:beta:convert",
+    "command": "force:package:convert",
     "plugin": "@salesforce/plugin-packaging",
     "flags": [
       "apiversion",
@@ -52,10 +52,10 @@
       "targetdevhubusername",
       "wait"
     ],
-    "alias": []
+    "alias": ["force:package:beta:convert"]
   },
   {
-    "command": "force:package:beta:create",
+    "command": "force:package:create",
     "plugin": "@salesforce/plugin-packaging",
     "flags": [
       "apiversion",
@@ -70,16 +70,16 @@
       "path",
       "targetdevhubusername"
     ],
-    "alias": []
+    "alias": ["force:package:beta:create"]
   },
   {
-    "command": "force:package:beta:delete",
+    "command": "force:package:delete",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "noprompt", "package", "targetdevhubusername", "undelete"],
-    "alias": []
+    "alias": ["force:package:beta:delete"]
   },
   {
-    "command": "force:package:beta:install",
+    "command": "force:package:install",
     "plugin": "@salesforce/plugin-packaging",
     "flags": [
       "apexcompile",
@@ -95,40 +95,40 @@
       "upgradetype",
       "wait"
     ],
-    "alias": []
+    "alias": ["force:package:beta:install"]
   },
   {
-    "command": "force:package:beta:install:report",
+    "command": "force:package:install:report",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "requestid", "targetusername"],
-    "alias": []
+    "alias": ["force:package:beta:install:report"]
   },
   {
-    "command": "force:package:beta:installed:list",
+    "command": "force:package:installed:list",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "targetusername"],
-    "alias": []
+    "alias": ["force:package:beta:installed:list"]
   },
   {
-    "command": "force:package:beta:list",
+    "command": "force:package:list",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "targetdevhubusername", "verbose"],
-    "alias": []
+    "alias": ["force:package:beta:list"]
   },
   {
-    "command": "force:package:beta:uninstall",
+    "command": "force:package:uninstall",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "package", "targetusername", "wait"],
-    "alias": []
+    "alias": ["force:package:beta:uninstall"]
   },
   {
-    "command": "force:package:beta:uninstall:report",
+    "command": "force:package:uninstall:report",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "requestid", "targetusername"],
-    "alias": []
+    "alias": ["force:package:beta:uninstall:report"]
   },
   {
-    "command": "force:package:beta:update",
+    "command": "force:package:update",
     "plugin": "@salesforce/plugin-packaging",
     "flags": [
       "apiversion",
@@ -140,10 +140,10 @@
       "package",
       "targetdevhubusername"
     ],
-    "alias": []
+    "alias": ["force:package:beta:update"]
   },
   {
-    "command": "force:package:beta:version:create",
+    "command": "force:package:version:create",
     "plugin": "@salesforce/plugin-packaging",
     "flags": [
       "apiversion",
@@ -173,34 +173,34 @@
       "versionnumber",
       "wait"
     ],
-    "alias": []
+    "alias": ["force:package:beta:version:create"]
   },
   {
-    "command": "force:package:beta:version:create:list",
+    "command": "force:package:version:create:list",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "createdlastdays", "json", "loglevel", "status", "targetdevhubusername"],
-    "alias": []
+    "alias": ["force:package:beta:version:create:list"]
   },
   {
-    "command": "force:package:beta:version:create:report",
+    "command": "force:package:version:create:report",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "packagecreaterequestid", "targetdevhubusername"],
-    "alias": []
+    "alias": ["force:package:beta:version:create:report"]
   },
   {
-    "command": "force:package:beta:version:delete",
+    "command": "force:package:version:delete",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "noprompt", "package", "targetdevhubusername", "undelete"],
-    "alias": []
+    "alias": ["force:package:beta:version:delete"]
   },
   {
-    "command": "force:package:beta:version:displayancestry",
+    "command": "force:package:version:displayancestry",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "dotcode", "json", "loglevel", "package", "targetdevhubusername", "verbose"],
-    "alias": []
+    "alias": ["force:package:beta:version:displayancestry"]
   },
   {
-    "command": "force:package:beta:version:list",
+    "command": "force:package:version:list",
     "plugin": "@salesforce/plugin-packaging",
     "flags": [
       "apiversion",
@@ -215,22 +215,22 @@
       "targetdevhubusername",
       "verbose"
     ],
-    "alias": []
+    "alias": ["force:package:beta:version:list"]
   },
   {
-    "command": "force:package:beta:version:promote",
+    "command": "force:package:version:promote",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "noprompt", "package", "targetdevhubusername"],
-    "alias": []
+    "alias": ["force:package:beta:version:promote"]
   },
   {
-    "command": "force:package:beta:version:report",
+    "command": "force:package:version:report",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["apiversion", "json", "loglevel", "package", "targetdevhubusername", "verbose"],
-    "alias": []
+    "alias": ["force:package:beta:version:report"]
   },
   {
-    "command": "force:package:beta:version:update",
+    "command": "force:package:version:update",
     "plugin": "@salesforce/plugin-packaging",
     "flags": [
       "apiversion",
@@ -244,6 +244,6 @@
       "versiondescription",
       "versionname"
     ],
-    "alias": []
+    "alias": ["force:package:beta:version:update"]
   }
 ]

--- a/messages/package1_version_create.md
+++ b/messages/package1_version_create.md
@@ -90,4 +90,4 @@ Successfully uploaded package [%s]
 # QUEUED
 
 PackageUploadRequest has been enqueued. You can query the status using
-sfdx force:package1:beta:version:create:get -i %s -u %s
+sfdx force:package1:version:create:get -i %s -u %s

--- a/messages/package_install.md
+++ b/messages/package_install.md
@@ -8,10 +8,10 @@ For package upgrades, to specify options for component deprecation or deletion o
 
 # examples
 
-$ sfdx force:package:beta:install --package 04t... -u me@example.com
-$ sfdx force:package:beta:install --package awesome_package_alias
-$ sfdx force:package:beta:install --package "Awesome Package Alias"
-$ sfdx force:package:beta:install --package 04t... -t DeprecateOnly
+$ sfdx force:package:install --package 04t... -u me@example.com
+$ sfdx force:package:install --package awesome_package_alias
+$ sfdx force:package:install --package "Awesome Package Alias"
+$ sfdx force:package:install --package 04t... -t DeprecateOnly
 
 # wait
 
@@ -118,7 +118,7 @@ This command is supported only on API versions 36.0 and higher
 # packageInstallInProgress
 
 PackageInstallRequest is currently InProgress. You can continue to query the status using
-sfdx force:package:beta:install:report -i %s -u %s
+sfdx force:package:install:report -i %s -u %s
 
 # packageInstallError
 

--- a/messages/package_uninstall.md
+++ b/messages/package_uninstall.md
@@ -4,15 +4,15 @@ uninstall a second-generation package from the target org
 
 Specify the package ID for a second-generation package.
 
-To list the org’s installed packages, run "sfdx force:package:beta:installed:list".
+To list the org’s installed packages, run "sfdx force:package:installed:list".
 
 To uninstall a first-generation package, from Setup, enter Installed Packages in the Quick Find box, then select Installed Packages.
 
 # examples
 
-$ sfdx force:package:beta:uninstall -p 04t... -u me@example.com
-$ sfdx force:package:beta:uninstall -p undesirable_package_alias
-$ sfdx force:package:beta:uninstall -p "Undesirable Package Alias"
+$ sfdx force:package:uninstall -p 04t... -u me@example.com
+$ sfdx force:package:uninstall -p undesirable_package_alias
+$ sfdx force:package:uninstall -p "Undesirable Package Alias"
 
 # wait
 
@@ -33,7 +33,7 @@ The ID (starts with 04t) or alias of the package version to uninstall.
 # InProgress
 
 PackageUninstallRequest is currently InProgress.
-You can continue to query the status using sfdx force:package:beta:uninstall:report -i %s -u %s
+You can continue to query the status using sfdx force:package:uninstall:report -i %s -u %s
 
 # Success
 

--- a/messages/package_uninstall_report.md
+++ b/messages/package_uninstall_report.md
@@ -4,8 +4,8 @@ retrieve status of package uninstall request
 
 # examples
 
-$ sfdx force:package:beta:uninstall:report -i 06y...
-$ sfdx force:package:beta:uninstall:report -i 06y... -u me@example.com
+$ sfdx force:package:uninstall:report -i 06y...
+$ sfdx force:package:uninstall:report -i 06y... -u me@example.com
 
 # requestId
 
@@ -18,7 +18,7 @@ The ID of the package uninstall request you want to check.
 # InProgress
 
 PackageUninstallRequest is currently InProgress. You can continue to query the status using
-sfdx force:package:beta:uninstall:report -i %s -u %s
+sfdx force:package:uninstall:report -i %s -u %s
 
 # Unknown
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@salesforce/command": "^5.2.33",
     "@salesforce/core": "^3.32.11",
     "@salesforce/kit": "^1.8.0",
-    "@salesforce/packaging": "^1.1.3",
+    "@salesforce/packaging": "^1.1.6",
     "chalk": "^4.1.2",
     "tslib": "^2"
   },

--- a/package.json
+++ b/package.json
@@ -97,25 +97,20 @@
             "description": "develop first-generation managed and unmanaged packages",
             "longDescription": "Use the package1 commands to create and view first-generation package versions in your Dev Hub org.",
             "subtopics": {
-              "beta": {
-                "description": "The commands in this topic are in beta release.",
+              "version": {
+                "description": "first-generation manage package versions",
+                "longDescription": "Use the package version commands to first-generation manage package versions.",
                 "subtopics": {
-                  "version": {
-                    "description": "first-generation manage package versions",
-                    "longDescription": "Use the package version commands to first-generation manage package versions.",
-                    "subtopics": {
-                      "create": {
-                        "description": "create package versions",
-                        "longDescription": "Use the package version list command to list package versions."
-                      },
-                      "display": {
-                        "description": "display package versions",
-                        "longDescription": "Use the package version list command to list package versions."
-                      },
-                      "list": {
-                        "description": "list package versions"
-                      }
-                    }
+                  "create": {
+                    "description": "create package versions",
+                    "longDescription": "Use the package version list command to list package versions."
+                  },
+                  "display": {
+                    "description": "display package versions",
+                    "longDescription": "Use the package version list command to list package versions."
+                  },
+                  "list": {
+                    "description": "list package versions"
                   }
                 }
               }
@@ -129,28 +124,23 @@
               "name": "Unlocked Packages and Managed 2GPs"
             },
             "subtopics": {
-              "beta": {
-                "description": "The commands in this topic are in beta release.",
+              "version": {
+                "description": "manage package versions",
+                "longDescription": "Use the package version commands to manage package versions.",
                 "subtopics": {
-                  "version": {
-                    "description": "manage package versions",
-                    "longDescription": "Use the package version commands to manage package versions.",
-                    "subtopics": {
-                      "create": {
-                        "description": "create package versions",
-                        "longDescription": "Use the package version list command to list package versions."
-                      }
-                    }
-                  },
-                  "uninstall": {
-                    "description": "uninstall packages",
-                    "longDescription": "Use the package uninstall commands to uninstall packages."
-                  },
-                  "install": {
-                    "description": "install packages",
-                    "longDescription": "Use the package install commands to install packages."
+                  "create": {
+                    "description": "create package versions",
+                    "longDescription": "Use the package version list command to list package versions."
                   }
                 }
+              },
+              "uninstall": {
+                "description": "uninstall packages",
+                "longDescription": "Use the package uninstall commands to uninstall packages."
+              },
+              "install": {
+                "description": "install packages",
+                "longDescription": "Use the package install commands to install packages."
               }
             }
           }

--- a/src/commands/force/package/convert.ts
+++ b/src/commands/force/package/convert.ts
@@ -23,6 +23,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_
 const pvcMessages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_version_create');
 
 export class PackageConvert extends SfdxCommand {
+  public static aliases = ['force:package:beta:convert'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresDevhubUsername = true;

--- a/src/commands/force/package/create.ts
+++ b/src/commands/force/package/create.ts
@@ -14,6 +14,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_create');
 
 export class PackageCreateCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:create'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresDevhubUsername = true;

--- a/src/commands/force/package/delete.ts
+++ b/src/commands/force/package/delete.ts
@@ -14,6 +14,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_delete');
 
 export class PackageDeleteCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:delete'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresDevhubUsername = true;

--- a/src/commands/force/package/install.ts
+++ b/src/commands/force/package/install.ts
@@ -28,6 +28,7 @@ const securityType = { AllUsers: 'full', AdminsOnly: 'none' };
 const upgradeType = { Delete: 'delete-only', DeprecateOnly: 'deprecate-only', Mixed: 'mixed-mode' };
 
 export class Install extends SfdxCommand {
+  public static aliases = ['force:package:beta:install'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresUsername = true;

--- a/src/commands/force/package/install/report.ts
+++ b/src/commands/force/package/install/report.ts
@@ -9,11 +9,16 @@ import * as os from 'os';
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
 import { PackagingSObjects, SubscriberPackageVersion } from '@salesforce/packaging';
+import { Install as InstallCommand } from '../install';
+
+type PackageInstallRequest = PackagingSObjects.PackageInstallRequest;
 
 Messages.importMessagesDirectory(__dirname);
-const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_uninstall_report');
+const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_install_report');
+const installMsgs = Messages.loadMessages('@salesforce/plugin-packaging', 'package_install');
 
-export class PackageUninstallReportCommand extends SfdxCommand {
+export class Report extends SfdxCommand {
+  public static aliases = ['force:package:beta:install:report'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresUsername = true;
@@ -23,22 +28,17 @@ export class PackageUninstallReportCommand extends SfdxCommand {
       description: messages.getMessage('requestId'),
       longDescription: messages.getMessage('requestIdLong'),
       required: true,
-      validate: (id) => {
-        if (/^06y.{12,15}$/.test(id)) {
-          return true;
-        }
-        throw messages.createError('packageIdInvalid');
-      },
     }),
   };
 
-  public async run(): Promise<PackagingSObjects.SubscriberPackageVersionUninstallRequest> {
-    const requestId = this.flags.requestid as string;
-    const result = await SubscriberPackageVersion.uninstallStatus(requestId, this.org.getConnection());
+  public async run(): Promise<PackageInstallRequest> {
+    const connection = this.org.getConnection();
+    const pkgInstallRequest = await SubscriberPackageVersion.getInstallRequest(
+      this.flags.requestid as string,
+      connection
+    );
+    InstallCommand.parseStatus(pkgInstallRequest, this.ux, installMsgs, this.org.getUsername());
 
-    const arg = result.Status === 'Success' ? [result.SubscriberPackageVersionId] : [result.Id, this.org.getUsername()];
-    this.ux.log(messages.getMessage(result.Status, arg));
-
-    return result;
+    return pkgInstallRequest;
   }
 }

--- a/src/commands/force/package/installed/list.ts
+++ b/src/commands/force/package/installed/list.ts
@@ -25,6 +25,7 @@ export type PackageInstalledListResult = {
 };
 
 export class PackageInstalledListCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:installed:list'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresUsername = true;

--- a/src/commands/force/package/list.ts
+++ b/src/commands/force/package/list.ts
@@ -33,6 +33,7 @@ export type Package2Result = Partial<
 >;
 
 export class PackageListCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:list'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresProject = true;

--- a/src/commands/force/package/uninstall.ts
+++ b/src/commands/force/package/uninstall.ts
@@ -17,6 +17,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_uninstall');
 
 export class PackageUninstallCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:uninstall'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresUsername = true;

--- a/src/commands/force/package/update.ts
+++ b/src/commands/force/package/update.ts
@@ -15,6 +15,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_
 const packageCreate = Messages.loadMessages('@salesforce/plugin-packaging', 'package_create');
 
 export class PackageUpdateCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:update'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresDevhubUsername = true;

--- a/src/commands/force/package/version/create.ts
+++ b/src/commands/force/package/version/create.ts
@@ -25,6 +25,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_version_create');
 
 export class PackageVersionCreateCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:version:create'];
   public static readonly summary = messages.getMessage('cliDescription');
   public static readonly description = messages.getMessage('cliLongDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);

--- a/src/commands/force/package/version/create/list.ts
+++ b/src/commands/force/package/version/create/list.ts
@@ -16,6 +16,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_
 const packaging = Messages.loadMessages('@salesforce/plugin-packaging', 'packaging');
 
 export class PackageVersionCreateListCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:version:create:list'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresDevhubUsername = true;

--- a/src/commands/force/package/version/create/report.ts
+++ b/src/commands/force/package/version/create/report.ts
@@ -20,6 +20,7 @@ const plMessages = Messages.loadMessages('@salesforce/plugin-packaging', 'packag
 
 const ERROR_LIMIT = 12;
 export class PackageVersionCreateReportCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:version:create:report'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresDevhubUsername = true;

--- a/src/commands/force/package/version/delete.ts
+++ b/src/commands/force/package/version/delete.ts
@@ -14,6 +14,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_version_delete');
 
 export class PackageVersionDeleteCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:version:delete'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresDevhubUsername = true;

--- a/src/commands/force/package/version/displayancestry.ts
+++ b/src/commands/force/package/version/displayancestry.ts
@@ -15,6 +15,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_displayancestry');
 
 export class PackageVersionDisplayAncestryCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:version:displayancestry'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly showProgress = false;

--- a/src/commands/force/package/version/list.ts
+++ b/src/commands/force/package/version/list.ts
@@ -50,6 +50,7 @@ export type PackageVersionListCommandResult = Omit<
 };
 
 export class PackageVersionListCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:version:list'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresDevhubUsername = true;

--- a/src/commands/force/package/version/promote.ts
+++ b/src/commands/force/package/version/promote.ts
@@ -14,6 +14,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_version_promote');
 
 export class PackageVersionPromoteCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:version:promote'];
   public static readonly description = messages.getMessage('cliDescription');
 
   public static readonly examples = messages.getMessage('examples').split(os.EOL);

--- a/src/commands/force/package/version/report.ts
+++ b/src/commands/force/package/version/report.ts
@@ -25,6 +25,7 @@ export type PackageVersionReportResultModified = Omit<
   HasMetadataRemoved: boolean | string;
 };
 export class PackageVersionReportCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:version:report'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresDevhubUsername = true;

--- a/src/commands/force/package/version/update.ts
+++ b/src/commands/force/package/version/update.ts
@@ -14,6 +14,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_version_update');
 
 export class PackageVersionUpdateCommand extends SfdxCommand {
+  public static aliases = ['force:package:beta:version:update'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresDevhubUsername = true;

--- a/src/commands/force/package1/version/create.ts
+++ b/src/commands/force/package1/version/create.ts
@@ -16,6 +16,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package1
 type PackageUploadRequest = PackagingSObjects.PackageUploadRequest;
 
 export class Package1VersionCreateCommand extends SfdxCommand {
+  public static aliases = ['force:package1:beta:version:create'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly requiresUsername = true;
   public static readonly requiresProject = true;

--- a/src/commands/force/package1/version/create/get.ts
+++ b/src/commands/force/package1/version/create/get.ts
@@ -14,6 +14,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package1_version_create_get');
 
 export class Package1VersionCreateGetCommand extends SfdxCommand {
+  public static aliases = ['force:package1:beta:version:create:get'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   public static readonly requiresUsername = true;

--- a/src/commands/force/package1/version/display.ts
+++ b/src/commands/force/package1/version/display.ts
@@ -13,6 +13,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package1_version_display');
 
 export class Package1VersionDisplayCommand extends SfdxCommand {
+  public static aliases = ['force:package1:beta:version:display'];
   public static readonly description = messages.getMessage('description');
   public static readonly requiresUsername = true;
   public static readonly flagsConfig: FlagsConfig = {

--- a/src/commands/force/package1/version/list.ts
+++ b/src/commands/force/package1/version/list.ts
@@ -13,6 +13,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package1_version_list');
 
 export class Package1VersionListCommand extends SfdxCommand {
+  public static aliases = ['force:package1:beta:version:list'];
   public static readonly description = messages.getMessage('cliDescription');
   public static readonly requiresUsername = true;
   public static readonly flagsConfig: FlagsConfig = {

--- a/test/commands/force/package/install.nut.ts
+++ b/test/commands/force/package/install.nut.ts
@@ -36,32 +36,32 @@ describe('package install', () => {
   });
 
   it('should install ElectronBranding package with polling', () => {
-    const command = 'force:package:beta:install -p 04t6A000002zgKSQAY -w 20';
+    const command = 'force:package:install -p 04t6A000002zgKSQAY -w 20';
     const output = execCmd(command, { ensureExitCode: 0, timeout: Duration.minutes(20).milliseconds }).shellOutput
       .stdout;
     expect(output).to.contain('Successfully installed package');
   });
 
   it('should install DFXP Escape Room package (async) and report', () => {
-    const installCommand = 'force:package:beta:install -p 04t6A000002zgKSQAY --json';
+    const installCommand = 'force:package:install -p 04t6A000002zgKSQAY --json';
     const installJson = execCmd<PackageInstallRequest>(installCommand, { ensureExitCode: 0 }).jsonOutput.result;
     expect(installJson).to.have.property('Status', 'IN_PROGRESS');
 
-    const reportCommand = `force:package:beta:install:report -i ${installJson.Id} --json`;
+    const reportCommand = `force:package:install:report -i ${installJson.Id} --json`;
     const reportJson = execCmd<PackageInstallRequest>(reportCommand, { ensureExitCode: 0 }).jsonOutput.result;
     expect(reportJson).to.have.property('Status');
     expect(['IN_PROGRESS', 'SUCCESS']).to.include(reportJson.Status);
   });
 
   it('should start an uninstall request, and report on it', () => {
-    const uninstallCommand = 'force:package:beta:uninstall -p 04t6A000002zgKSQAY --json -w 0';
+    const uninstallCommand = 'force:package:uninstall -p 04t6A000002zgKSQAY --json -w 0';
     const uninstallRequest = execCmd<PackageUninstallRequest>(uninstallCommand, {
       ensureExitCode: 0,
     }).jsonOutput.result;
     expect(['InProgress', 'Success']).to.include(uninstallRequest.Status);
     expect(uninstallRequest.Id.startsWith('06y')).to.be.true;
 
-    const uninstallReportCommand = `force:package:beta:uninstall:report -i ${uninstallRequest.Id} --json`;
+    const uninstallReportCommand = `force:package:uninstall:report -i ${uninstallRequest.Id} --json`;
     const uninstallReportResult = execCmd(uninstallReportCommand, { ensureExitCode: 0 }).jsonOutput.result;
     expect(uninstallReportResult).to.have.all.keys(
       'Id',

--- a/test/commands/force/package/install.test.ts
+++ b/test/commands/force/package/install.test.ts
@@ -185,7 +185,7 @@ describe('force:package:install', () => {
       queryStub = stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').resolves(subscriberPackageVersion);
       const result = await runCmd(['-p', myPackageVersion04t]);
       expect(uxLogStub.calledOnce).to.be.true;
-      const msg = `PackageInstallRequest is currently InProgress. You can continue to query the status using${EOL}sfdx force:package:beta:install:report -i 0Hf1h0000006sh2CAA -u test@user.com`;
+      const msg = `PackageInstallRequest is currently InProgress. You can continue to query the status using${EOL}sfdx force:package:install:report -i 0Hf1h0000006sh2CAA -u test@user.com`;
       expect(uxLogStub.args[0][0]).to.equal(msg);
       expect(result).to.deep.equal(pkgInstallRequest);
       expect(installStub.args[0][0]).to.deep.equal(pkgInstallCreateRequest);
@@ -198,7 +198,7 @@ describe('force:package:install', () => {
       queryStub = stubMethod($$.SANDBOX, Connection.prototype, 'singleRecordQuery').resolves(subscriberPackageVersion);
       const result = await runCmd(['-p', myPackageVersion04t]);
       expect(uxLogStub.calledOnce).to.be.true;
-      const msg = `PackageInstallRequest is currently InProgress. You can continue to query the status using${EOL}sfdx force:package:beta:install:report -i 0Hf1h0000006sh2CAA -u test@user.com`;
+      const msg = `PackageInstallRequest is currently InProgress. You can continue to query the status using${EOL}sfdx force:package:install:report -i 0Hf1h0000006sh2CAA -u test@user.com`;
       expect(uxLogStub.args[0][0]).to.equal(msg);
       expect(result).to.deep.equal(pkgInstallRequest);
       expect(installStub.args[0][0]).to.deep.equal(pkgInstallCreateRequest);
@@ -353,7 +353,7 @@ describe('force:package:install', () => {
 
       expect(uxLogStub.calledTwice).to.be.true;
       expect(uxLogStub.args[0][0]).to.equal(warningMsg);
-      const msg = `PackageInstallRequest is currently InProgress. You can continue to query the status using${EOL}sfdx force:package:beta:install:report -i 0Hf1h0000006sh2CAA -u test@user.com`;
+      const msg = `PackageInstallRequest is currently InProgress. You can continue to query the status using${EOL}sfdx force:package:install:report -i 0Hf1h0000006sh2CAA -u test@user.com`;
       expect(uxLogStub.args[1][0]).to.equal(msg);
       expect(result).to.deep.equal(pkgInstallRequest);
     });

--- a/test/commands/force/package/install.test.ts
+++ b/test/commands/force/package/install.test.ts
@@ -12,7 +12,7 @@ import { Config } from '@oclif/core';
 import { expect } from 'chai';
 import { PackageEvents, PackagingSObjects, SubscriberPackageVersion } from '@salesforce/packaging';
 import { Result } from '@salesforce/command';
-import { Install } from '../../../../src/commands/force/package/beta/install';
+import { Install } from '../../../../src/commands/force/package/install';
 import InstallValidationStatus = PackagingSObjects.InstallValidationStatus;
 
 const myPackageVersion04t = '04t6A000002zgKSQAY';

--- a/test/commands/force/package/installReport.test.ts
+++ b/test/commands/force/package/installReport.test.ts
@@ -12,7 +12,7 @@ import { Config } from '@oclif/core';
 import { expect } from 'chai';
 import { PackagingSObjects, SubscriberPackageVersion } from '@salesforce/packaging';
 import { Result } from '@salesforce/command';
-import { Report } from '../../../../src/commands/force/package/beta/install/report';
+import { Report } from '../../../../src/commands/force/package/install/report';
 
 describe('force:package:install:report', () => {
   const $$ = new TestContext();

--- a/test/commands/force/package/installReport.test.ts
+++ b/test/commands/force/package/installReport.test.ts
@@ -103,7 +103,7 @@ describe('force:package:install:report', () => {
     const result = await runCmd(['-i', pkgInstallRequest.Id]);
     expect(result).to.deep.equal(pkgInstallRequest);
     expect(uxLogStub.calledOnce).to.be.true;
-    const msg = `PackageInstallRequest is currently InProgress. You can continue to query the status using${EOL}sfdx force:package:beta:install:report -i 0Hf1h0000006sh2CAA -u test@user.com`;
+    const msg = `PackageInstallRequest is currently InProgress. You can continue to query the status using${EOL}sfdx force:package:install:report -i 0Hf1h0000006sh2CAA -u test@user.com`;
     expect(uxLogStub.args[0][0]).to.equal(msg);
   });
 

--- a/test/commands/force/package/packageConvert.test.ts
+++ b/test/commands/force/package/packageConvert.test.ts
@@ -10,7 +10,7 @@ import { Org } from '@salesforce/core';
 import { TestContext } from '@salesforce/core/lib/testSetup';
 import { Config } from '@oclif/core';
 import { Package, PackagingSObjects } from '@salesforce/packaging';
-import { PackageConvert } from '../../../../src/commands/force/package/beta/convert';
+import { PackageConvert } from '../../../../src/commands/force/package/convert';
 import Package2VersionStatus = PackagingSObjects.Package2VersionStatus;
 
 const CONVERTED_FROM_PACKAGE_ID = '033xx0000004Gmn';

--- a/test/commands/force/package/packageCreateAndDelete.nut.ts
+++ b/test/commands/force/package/packageCreateAndDelete.nut.ts
@@ -27,18 +27,18 @@ describe('package create/update/delete', () => {
       pkgName = `test-pkg-${Date.now()}`;
     });
     it('should create a package - human readable results', () => {
-      const command = `force:package:beta:create -n ${pkgName} -v ${session.hubOrg.username} -t Unlocked -r ./force-app`;
+      const command = `force:package:create -n ${pkgName} -v ${session.hubOrg.username} -t Unlocked -r ./force-app`;
       const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(output).to.contain('=== Ids');
       expect(output).to.match(/Package Id\s+?0Ho/);
     });
     it('should update a package - human readable results', () => {
-      const command = `force:package:beta:update --package ${pkgName} --description "My new description" -v ${session.hubOrg.username}`;
+      const command = `force:package:update --package ${pkgName} --description "My new description" -v ${session.hubOrg.username}`;
       const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(output).to.match(/Successfully updated the package\.\s+0Ho/);
     });
     it('should delete a package - human readable results', () => {
-      const command = `force:package:beta:delete -p ${pkgName} -v ${session.hubOrg.username} --noprompt`;
+      const command = `force:package:delete -p ${pkgName} -v ${session.hubOrg.username} --noprompt`;
       const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(output).to.contain('Successfully deleted the package. 0Ho');
     });
@@ -51,7 +51,7 @@ describe('package create/update/delete', () => {
     });
 
     it('should create a package - json results', () => {
-      const command = `force:package:beta:create -n ${pkgName} -v ${session.hubOrg.username} -t Unlocked -r ./force-app --json`;
+      const command = `force:package:create -n ${pkgName} -v ${session.hubOrg.username} -t Unlocked -r ./force-app --json`;
       const output = execCmd<{ Id: string }>(command, { ensureExitCode: 0 }).jsonOutput;
       pkgId = output.result.Id;
       expect(output.status).to.equal(0);
@@ -60,7 +60,7 @@ describe('package create/update/delete', () => {
     });
 
     it('should update a package - json results', () => {
-      const command = `force:package:beta:update --package ${pkgName} --description "My new description" -v ${session.hubOrg.username} --json`;
+      const command = `force:package:update --package ${pkgName} --description "My new description" -v ${session.hubOrg.username} --json`;
       const output = execCmd<{ id: string }>(command, { ensureExitCode: 0 }).jsonOutput;
       expect(output.status).to.equal(0);
       expect(output.result).to.have.property('id');
@@ -68,7 +68,7 @@ describe('package create/update/delete', () => {
     });
 
     it('should delete a package - json results', () => {
-      const command = `force:package:beta:delete -p ${pkgId} -v ${session.hubOrg.username} --json`;
+      const command = `force:package:delete -p ${pkgId} -v ${session.hubOrg.username} --json`;
       const output = execCmd<{ id: string; success: boolean; errors: [] }>(command, { ensureExitCode: 0 }).jsonOutput;
       expect(output.result.id).to.match(/0Ho.{12,15}/);
       expect(output.result.success).to.be.true;

--- a/test/commands/force/package/packageInstalledList.nut.ts
+++ b/test/commands/force/package/packageInstalledList.nut.ts
@@ -7,7 +7,7 @@
 
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
-import { PackageInstalledListResult } from '../../../../src/commands/force/package/beta/installed/list';
+import { PackageInstalledListResult } from '../../../../src/commands/force/package/installed/list';
 
 describe('package:installed:list', () => {
   let session: TestSession;

--- a/test/commands/force/package/packageInstalledList.nut.ts
+++ b/test/commands/force/package/packageInstalledList.nut.ts
@@ -24,7 +24,7 @@ describe('package:installed:list', () => {
     await session?.clean();
   });
   it('should list all installed packages in dev hub - human readable results', () => {
-    const command = `force:package:beta:installed:list  -u ${session.hubOrg.username}`;
+    const command = `force:package:installed:list  -u ${session.hubOrg.username}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.match(
       /ID\s+?Package ID\s+?Package Name\s+?Namespace\s+?Package Version ID\s+?Version Name\s+?Version/
@@ -32,7 +32,7 @@ describe('package:installed:list', () => {
   });
 
   it('should list all installed packages in dev hub - json', () => {
-    const command = `force:package:beta:installed:list  -u ${session.hubOrg.username} --json`;
+    const command = `force:package:installed:list  -u ${session.hubOrg.username} --json`;
     const output = execCmd<PackageInstalledListResult[]>(command, { ensureExitCode: 0 }).jsonOutput.result[0];
     expect(output).to.have.keys(
       'Id',

--- a/test/commands/force/package/packageList.nut.ts
+++ b/test/commands/force/package/packageList.nut.ts
@@ -23,13 +23,13 @@ describe('package list', () => {
     await session?.clean();
   });
   it('should list packages in dev hub - human readable results', () => {
-    const command = `force:package:beta:list -v ${session.hubOrg.username}`;
+    const command = `force:package:list -v ${session.hubOrg.username}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.contain('=== Packages');
     expect(output).to.match(/Namespace Prefix\s+?Name\s+?Id\s+?Alias\s+?Description\s+?Type/);
   });
   it('should list packages in dev hub - verbose human readable results', () => {
-    const command = `force:package:beta:list -v ${session.hubOrg.username} --verbose`;
+    const command = `force:package:list -v ${session.hubOrg.username} --verbose`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.contain('=== Packages');
     expect(output).to.match(
@@ -39,7 +39,7 @@ describe('package list', () => {
   it('should list packages in dev hub - json results', async () => {
     const hubOrg = await Org.create({ aliasOrUsername: session.hubOrg.username });
     const packages = await Package.list(hubOrg.getConnection());
-    const command = `force:package:beta:list -v ${session.hubOrg.username} --json`;
+    const command = `force:package:list -v ${session.hubOrg.username} --json`;
     const output = execCmd<{ [key: string]: unknown }>(command, { ensureExitCode: 0 }).jsonOutput;
     const keys = [
       'Id',

--- a/test/commands/force/package/packageUninstall.test.ts
+++ b/test/commands/force/package/packageUninstall.test.ts
@@ -10,7 +10,7 @@ import { TestContext } from '@salesforce/core/lib/testSetup';
 import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { Config } from '@oclif/core';
 import { assert, expect } from 'chai';
-import { PackageUninstallCommand } from '../../../../src/commands/force/package/beta/uninstall';
+import { PackageUninstallCommand } from '../../../../src/commands/force/package/uninstall';
 
 describe('force:package:uninstall', () => {
   const $$ = new TestContext();

--- a/test/commands/force/package/packageUninstall.test.ts
+++ b/test/commands/force/package/packageUninstall.test.ts
@@ -76,7 +76,7 @@ describe('force:package:uninstall', () => {
     expect(result.Status).to.equal('InProgress');
     expect(uxStub.callCount).to.equal(1);
     expect(uxStub.firstCall.args[0]).to.equal(
-      `PackageUninstallRequest is currently InProgress.${os.EOL}You can continue to query the status using sfdx force:package:beta:uninstall:report -i 06y23000000002MXXX -u test@user.com`
+      `PackageUninstallRequest is currently InProgress.${os.EOL}You can continue to query the status using sfdx force:package:uninstall:report -i 06y23000000002MXXX -u test@user.com`
     );
   });
 

--- a/test/commands/force/package/packageVersion.nut.ts
+++ b/test/commands/force/package/packageVersion.nut.ts
@@ -16,7 +16,7 @@ import {
   PackagingSObjects,
   VersionNumber,
 } from '@salesforce/packaging';
-import { PackageVersionListCommandResult } from '../../../../src/commands/force/package/beta/version/list';
+import { PackageVersionListCommandResult } from '../../../../src/commands/force/package/version/list';
 
 describe('package:version:*', () => {
   let session: TestSession;

--- a/test/commands/force/package/packageVersion.nut.ts
+++ b/test/commands/force/package/packageVersion.nut.ts
@@ -32,7 +32,7 @@ describe('package:version:*', () => {
     });
 
     packageId = execCmd<{ Id: string }>(
-      `force:package:beta:create -n ${pkgName} -v ${session.hubOrg.username} --json -t Unlocked -r ./force-app`,
+      `force:package:create -n ${pkgName} -v ${session.hubOrg.username} --json -t Unlocked -r ./force-app`,
       {
         ensureExitCode: 0,
       }
@@ -46,7 +46,7 @@ describe('package:version:*', () => {
   describe('package:version:create', () => {
     it('should create a new package version (human)', () => {
       const result = execCmd(
-        `force:package:beta:version:create --package ${pkgName} -x --codecoverage --versiondescription "Initial version"`,
+        `force:package:version:create --package ${pkgName} -x --codecoverage --versiondescription "Initial version"`,
         { ensureExitCode: 0 }
       ).shellOutput.stdout;
       expect(result).to.include("Package version creation request status is '");
@@ -56,7 +56,7 @@ describe('package:version:*', () => {
     // package:version:create --wait --json is tested in versionPromoteUpdate.nut.ts
     it('should create a new package version and wait (human)', () => {
       const result = execCmd(
-        `force:package:beta:version:create --package ${pkgName} --wait 20 -x --codecoverage --versiondescription "Initial version" --versionnumber 1.0.0.NEXT`,
+        `force:package:version:create --package ${pkgName} --wait 20 -x --codecoverage --versiondescription "Initial version" --versionnumber 1.0.0.NEXT`,
         { ensureExitCode: 0, timeout: Duration.minutes(20).milliseconds }
       ).shellOutput.stdout;
       expect(result).to.match(/Successfully created the package version \[08c.{15}]/);
@@ -69,7 +69,7 @@ describe('package:version:*', () => {
 
     it('should create a new package version (json)', () => {
       const result = execCmd<PackageVersionCreateRequestResult>(
-        `force:package:beta:version:create --package ${pkgName} --json --tag tag --branch branch -x --codecoverage --versiondescription "Initial version"`,
+        `force:package:version:create --package ${pkgName} --json --tag tag --branch branch -x --codecoverage --versiondescription "Initial version"`,
         { ensureExitCode: 0 }
       ).jsonOutput.result;
       expect(result).to.have.all.keys(
@@ -107,7 +107,7 @@ describe('package:version:*', () => {
   describe('package:version:create:report', () => {
     it('reports on status (json)', () => {
       const result = execCmd<PackageVersionCreateRequestResult[]>(
-        `force:package:beta:version:create:report -i ${packageVersionId} --json`,
+        `force:package:version:create:report -i ${packageVersionId} --json`,
         {
           ensureExitCode: 0,
         }
@@ -131,7 +131,7 @@ describe('package:version:*', () => {
 
     it('reports on status (human)', () => {
       const resultHuman = execCmd<PackageVersionCreateRequestResult[]>(
-        `force:package:beta:version:create:report -i ${packageVersionId}`,
+        `force:package:version:create:report -i ${packageVersionId}`,
         {
           ensureExitCode: 0,
         }
@@ -151,7 +151,7 @@ describe('package:version:*', () => {
 
   describe('package:version:create:list', () => {
     it('should list the package versions created (human)', async () => {
-      const command = `force:package:beta:version:create:list -v ${session.hubOrg.username}`;
+      const command = `force:package:version:create:list -v ${session.hubOrg.username}`;
       const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(output).to.contain('=== Package Version Create Requests  [');
       expect(output).to.match(
@@ -160,7 +160,7 @@ describe('package:version:*', () => {
     });
 
     it('should list all of the successful package versions created', async () => {
-      const command = `force:package:beta:version:create:list --status Success -v ${session.hubOrg.username} --json`;
+      const command = `force:package:version:create:list --status Success -v ${session.hubOrg.username} --json`;
       const output = execCmd<[{ Status: string }]>(command, { ensureExitCode: 0 }).jsonOutput;
       output.result.forEach((result) => {
         expect(result.Status).to.equal('Success');
@@ -168,7 +168,7 @@ describe('package:version:*', () => {
     });
 
     it('should list all of the package versions created within the last 2 days', () => {
-      const command = `force:package:beta:version:create:list --createdlastdays 2 -v ${session.hubOrg.username} --json`;
+      const command = `force:package:version:create:list --createdlastdays 2 -v ${session.hubOrg.username} --json`;
       const output = execCmd<[{ CreatedDate: string }]>(command, { ensureExitCode: 0 }).jsonOutput;
       const keys = [
         'Id',
@@ -199,7 +199,7 @@ describe('package:version:*', () => {
     });
 
     it('should list the package versions created (json)', async () => {
-      const command = `force:package:beta:version:create:list -v ${session.hubOrg.username} --json`;
+      const command = `force:package:version:create:list -v ${session.hubOrg.username} --json`;
       const output = execCmd<{ [key: string]: unknown }>(command, { ensureExitCode: 0 }).jsonOutput;
       const keys = [
         'Id',
@@ -222,7 +222,7 @@ describe('package:version:*', () => {
   });
   describe('package:version:list', () => {
     it('should list package versions in dev hub - human readable results', () => {
-      const command = `force:package:beta:version:list -v ${session.hubOrg.username}`;
+      const command = `force:package:version:list -v ${session.hubOrg.username}`;
       const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(output).to.contain('=== Package Versions [');
       expect(output).to.match(
@@ -231,14 +231,14 @@ describe('package:version:*', () => {
     });
 
     it('should list package versions in dev hub - concise output', () => {
-      const command = `force:package:beta:version:list -v ${session.hubOrg.username} --concise`;
+      const command = `force:package:version:list -v ${session.hubOrg.username} --concise`;
       const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(output).to.contain('=== Package Versions [');
       expect(output).to.match(/Package Id\s+Version\s+Subscriber Package Version Id\s+Released/);
     });
 
     it('should list package versions modified in the last 5 days', () => {
-      const command = `force:package:beta:version:list -v ${session.hubOrg.username} --modifiedlastdays 5`;
+      const command = `force:package:version:list -v ${session.hubOrg.username} --modifiedlastdays 5`;
       const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(output).to.contain('=== Package Versions [');
       expect(output).to.match(
@@ -246,7 +246,7 @@ describe('package:version:*', () => {
       );
     });
     it('should list package versions created in the last 5 days', () => {
-      const command = `force:package:beta:version:list -v ${session.hubOrg.username} --createdlastdays 5`;
+      const command = `force:package:version:list -v ${session.hubOrg.username} --createdlastdays 5`;
       const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(output).to.contain('=== Package Versions [');
       expect(output).to.match(
@@ -254,7 +254,7 @@ describe('package:version:*', () => {
       );
     });
     it('should list installed packages in dev hub - verbose human readable results', () => {
-      const command = `force:package:beta:version:list -v ${session.hubOrg.username} --verbose`;
+      const command = `force:package:version:list -v ${session.hubOrg.username} --verbose`;
       const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(output).to.contain('=== Package Versions [');
       expect(output).to.match(
@@ -262,7 +262,7 @@ describe('package:version:*', () => {
       );
     });
     it('should list package versions in dev hub - json results', () => {
-      const command = `force:package:beta:version:list -v ${session.hubOrg.username} --json`;
+      const command = `force:package:version:list -v ${session.hubOrg.username} --json`;
       const output = execCmd<[PackageVersionListCommandResult]>(command, { ensureExitCode: 0 }).jsonOutput.result;
       const keys = [
         'Package2Id',
@@ -299,7 +299,7 @@ describe('package:version:*', () => {
       expect(output[0]).to.have.keys(keys);
     });
     it('should list package versions in dev hub - verbose json results', () => {
-      const command = `force:package:beta:version:list --verbose -v ${session.hubOrg.username} --json`;
+      const command = `force:package:version:list --verbose -v ${session.hubOrg.username} --json`;
       const output = execCmd<[PackageVersionListCommandResult]>(command, { ensureExitCode: 0 }).jsonOutput.result;
       const keys = [
         'Package2Id',
@@ -350,7 +350,7 @@ describe('package:version:*', () => {
 
     before(() => {
       // query for deletable package versions (released package versions can't be deleted)
-      const command = `force:package:beta:version:list -v ${session.hubOrg.username} -p ${packageId} --json`;
+      const command = `force:package:version:list -v ${session.hubOrg.username} -p ${packageId} --json`;
       const output = execCmd<[PackageVersionListCommandResult]>(command, { ensureExitCode: 0 }).jsonOutput.result;
       output.forEach((pkgVersion) => {
         if (!pkgVersion.IsReleased) {
@@ -365,7 +365,7 @@ describe('package:version:*', () => {
 
     it('will delete a package (json)', () => {
       const id = deletableVersionIds.pop();
-      const command = `force:package:beta:version:delete -p ${id} --json`;
+      const command = `force:package:version:delete -p ${id} --json`;
       const result = execCmd<[PackageSaveResult]>(command, { ensureExitCode: 0 }).jsonOutput.result;
       expect(result).to.have.property('success', true);
       expect(result).to.have.property('id', id);
@@ -374,7 +374,7 @@ describe('package:version:*', () => {
 
     it('will delete a package (human)', () => {
       const id = deletableVersionIds.pop();
-      const command = `force:package:beta:version:delete -p ${id} --noprompt`;
+      const command = `force:package:version:delete -p ${id} --noprompt`;
       const result = execCmd<[PackageSaveResult]>(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(result).to.contain(`Successfully deleted the package version. ${id}`);
     });
@@ -442,25 +442,25 @@ describe('package:version:*', () => {
       expect(project.getSfProjectJson().get('packageAliases')).to.have.property(ancestryPkgName);
     });
     it('will print the correct output (default)', () => {
-      const command = `force:package:beta:version:displayancestry -p ${ancestryPkgName}`;
+      const command = `force:package:version:displayancestry -p ${ancestryPkgName}`;
       const result = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(result).to.match(new RegExp(`^└─ ${sortedVersions[0].toString()}`));
     });
     it('will print the correct output (verbose)', () => {
-      const command = `force:package:beta:version:displayancestry -p ${ancestryPkgName} --verbose`;
+      const command = `force:package:version:displayancestry -p ${ancestryPkgName} --verbose`;
       const result = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(result).to.match(new RegExp(`^└─ ${sortedVersions[0].toString()}`));
       expect(result).to.match(/\d\.\d\.\d\.\d \(04t.{15}\)/);
     });
     it('will print the correct output (dotcode)', () => {
-      const command = `force:package:beta:version:displayancestry -p ${ancestryPkgName} --dotcode`;
+      const command = `force:package:version:displayancestry -p ${ancestryPkgName} --dotcode`;
       const result = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(result).to.contain('strict graph G {');
       expect(result).to.match(/node04t.{15} \[label="\d\.\d\.\d\.\d"]/);
       expect(result).to.match(/-- node04t.{15}/);
     });
     it('will print the correct output (json)', () => {
-      const command = `force:package:beta:version:displayancestry -p ${ancestryPkgName} --json`;
+      const command = `force:package:version:displayancestry -p ${ancestryPkgName} --json`;
       const result = execCmd<PackageAncestryNodeData>(command, { ensureExitCode: 0 }).jsonOutput.result;
       expect(result).to.have.all.keys('data', 'children');
       expect(result.data).to.have.all.keys(
@@ -477,7 +477,7 @@ describe('package:version:*', () => {
     });
 
     it('will print the correct output (json & dotcode)', () => {
-      const command = `force:package:beta:version:displayancestry -p ${ancestryPkgName} --dotcode --json`;
+      const command = `force:package:version:displayancestry -p ${ancestryPkgName} --dotcode --json`;
       const result = execCmd<PackageAncestryNodeData>(command, { ensureExitCode: 0 }).jsonOutput.result;
       expect(result).to.contain('strict graph G {');
       expect(result).to.match(/node04t.{15} \[label="\d\.\d\.\d\.\d"]/);

--- a/test/commands/force/package/packageVersionCreate.test.ts
+++ b/test/commands/force/package/packageVersionCreate.test.ts
@@ -11,7 +11,7 @@ import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { Config } from '@oclif/core';
 import { assert, expect } from 'chai';
 import { PackageVersion, PackageVersionCreateRequestResult, PackagingSObjects } from '@salesforce/packaging';
-import { PackageVersionCreateCommand } from '../../../../src/commands/force/package/beta/version/create';
+import { PackageVersionCreateCommand } from '../../../../src/commands/force/package/version/create';
 import Package2VersionStatus = PackagingSObjects.Package2VersionStatus;
 
 describe('force:package:version:create - tests', () => {

--- a/test/commands/force/package/packageVersionCreateReport.test.ts
+++ b/test/commands/force/package/packageVersionCreateReport.test.ts
@@ -11,7 +11,7 @@ import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { Config } from '@oclif/core';
 import { expect } from 'chai';
 import { PackageVersion, PackageVersionCreateRequestResult, PackagingSObjects } from '@salesforce/packaging';
-import { PackageVersionCreateReportCommand } from '../../../../src/commands/force/package/beta/version/create/report';
+import { PackageVersionCreateReportCommand } from '../../../../src/commands/force/package/version/create/report';
 
 import Package2VersionStatus = PackagingSObjects.Package2VersionStatus;
 

--- a/test/commands/force/package/version.delete.test.ts
+++ b/test/commands/force/package/version.delete.test.ts
@@ -11,7 +11,7 @@ import { Config } from '@oclif/core';
 import { expect } from 'chai';
 import { PackageSaveResult, PackageVersion } from '@salesforce/packaging';
 import { Result } from '@salesforce/command';
-import { PackageVersionDeleteCommand } from '../../../../src/commands/force/package/beta/version/delete';
+import { PackageVersionDeleteCommand } from '../../../../src/commands/force/package/version/delete';
 
 describe('force:package:version:delete', () => {
   const $$ = new TestContext();

--- a/test/commands/force/package/versionPromoteUpdate.nut.ts
+++ b/test/commands/force/package/versionPromoteUpdate.nut.ts
@@ -32,12 +32,12 @@ describe('package:version:promote / package:version:update', () => {
     });
 
     const id = execCmd<{ Id: string }>(
-      `force:package:beta:create --name ${pkgName} --loglevel debug --packagetype Unlocked --path force-app --description "Don't ease, don't ease, don't ease me in." --json`,
+      `force:package:create --name ${pkgName} --loglevel debug --packagetype Unlocked --path force-app --description "Don't ease, don't ease, don't ease me in." --json`,
       { ensureExitCode: 0 }
     ).jsonOutput.result.Id;
 
     const result = execCmd<PackageVersionCreateRequestResult>(
-      `force:package:beta:version:create --package ${id} --json --wait 20 --tag tag --branch branch -x --codecoverage --versiondescription "Initial version" --versionnumber 1.0.0.NEXT`,
+      `force:package:version:create --package ${id} --json --wait 20 --tag tag --branch branch -x --codecoverage --versiondescription "Initial version" --versionnumber 1.0.0.NEXT`,
       { ensureExitCode: 0, timeout: Duration.minutes(20).milliseconds }
     ).jsonOutput.result;
     expect(result).to.have.all.keys(
@@ -69,7 +69,7 @@ describe('package:version:promote / package:version:update', () => {
   });
 
   it('should promote a package (human readable)', () => {
-    const result = execCmd(`force:package:beta:version:promote --package ${packageId} --noprompt`, {
+    const result = execCmd(`force:package:version:promote --package ${packageId} --noprompt`, {
       ensureExitCode: 0,
     }).shellOutput.stdout;
     expect(result).to.contain('Successfully promoted the package version');
@@ -81,7 +81,7 @@ describe('package:version:promote / package:version:update', () => {
 
   it('should promote a package (--json)', () => {
     const result = execCmd<PackageSaveResult>(
-      `force:package:beta:version:promote --package ${packageId} --noprompt --json`,
+      `force:package:version:promote --package ${packageId} --noprompt --json`,
       {
         ensureExitCode: 0,
       }
@@ -93,7 +93,7 @@ describe('package:version:promote / package:version:update', () => {
   });
 
   it('should update a package (human readable)', () => {
-    const result = execCmd(`force:package:beta:version:update --package ${packageId} --branch MySuperCoolBranch`, {
+    const result = execCmd(`force:package:version:update --package ${packageId} --branch MySuperCoolBranch`, {
       ensureExitCode: 0,
     }).shellOutput.stdout;
     expect(result).to.contain(`Successfully updated the package version. ${packageId}`);
@@ -101,7 +101,7 @@ describe('package:version:promote / package:version:update', () => {
 
   it('should update a package (--json)', () => {
     const result = execCmd<PackageSaveResult>(
-      `force:package:beta:version:update --package ${packageId} --branch MySuperCoolBranch2 --json`,
+      `force:package:version:update --package ${packageId} --branch MySuperCoolBranch2 --json`,
       {
         ensureExitCode: 0,
       }

--- a/test/commands/force/package/versionReport.test.ts
+++ b/test/commands/force/package/versionReport.test.ts
@@ -13,7 +13,7 @@ import { PackageVersion, PackageVersionReportResult } from '@salesforce/packagin
 import {
   PackageVersionReportCommand,
   PackageVersionReportResultModified,
-} from '../../../../src/commands/force/package/beta/version/report';
+} from '../../../../src/commands/force/package/version/report';
 
 describe('force:package:version:report - tests', () => {
   const $$ = new TestContext();

--- a/test/commands/force/package1/versionCreate.nut.ts
+++ b/test/commands/force/package1/versionCreate.nut.ts
@@ -16,7 +16,7 @@ import { sleep } from '@salesforce/kit';
 type PackageUploadRequest = PackagingSObjects.PackageUploadRequest;
 
 const pollUntilComplete = async (id: string): Promise<PackageUploadRequest> => {
-  const result = execCmd<PackageUploadRequest>(`force:package1:beta:version:create:get -i ${id} -u 1gp --json`, {
+  const result = execCmd<PackageUploadRequest>(`force:package1:version:create:get -i ${id} -u 1gp --json`, {
     ensureExitCode: 0,
   }).jsonOutput.result;
   if (result.Status === 'SUCCESS') {
@@ -46,7 +46,7 @@ describe('package1:version:create', () => {
 
     execCmd(`auth:sfdxurl:store -f ${authPath} -a 1gp`, { cli: 'sfdx' });
 
-    packageId = execCmd<[{ MetadataPackageId: string }]>('force:package1:beta:version:list --json -u 1gp', {
+    packageId = execCmd<[{ MetadataPackageId: string }]>('force:package1:version:list --json -u 1gp', {
       ensureExitCode: 0,
     }).jsonOutput.result[0].MetadataPackageId;
   });
@@ -57,13 +57,13 @@ describe('package1:version:create', () => {
   });
   // we need to the run the synchronous command first, to avoid duplicate package version create API requests in the NUTs
   it(`should create a new 1gp package version for package id ${packageId} and wait`, () => {
-    const command = `force:package1:beta:version:create -n 1gpPackageNUT -i ${packageId} -w 5 -u 1gp`;
+    const command = `force:package1:version:create -n 1gpPackageNUT -i ${packageId} -w 5 -u 1gp`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output.trim()).to.match(/Successfully uploaded package \[04t.{15}]/);
   });
 
   it(`should create a new 1gp package version for package id ${packageId} and wait (json)`, () => {
-    const command = `force:package1:beta:version:create -n 1gpPackageNUT -i ${packageId} --json -w 5 -u 1gp`;
+    const command = `force:package1:version:create -n 1gpPackageNUT -i ${packageId} --json -w 5 -u 1gp`;
     const output = execCmd<PackageUploadRequest>(command, { ensureExitCode: 0 }).jsonOutput.result;
     expect(output.Status).to.equal('SUCCESS');
     expect(output.Id).to.be.a('string');
@@ -74,18 +74,18 @@ describe('package1:version:create', () => {
   });
 
   it(`should create a new 1gp package version for package id ${packageId} without waiting`, async () => {
-    const command = `force:package1:beta:version:create -n 1gpPackageNUT -i ${packageId} -u 1gp`;
+    const command = `force:package1:version:create -n 1gpPackageNUT -i ${packageId} -u 1gp`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.match(/PackageUploadRequest has been enqueued\./);
-    // sfdx force:package1:beta:version:create:get -i 0HD4p000000blVAGAY -u admin@integrationtestrelorgna40.org
-    expect(output).to.match(/sfdx force:package1:beta:version:create:get -i 0HD.{15} -u/);
+    // sfdx force:package1:version:create:get -i 0HD4p000000blVAGAY -u admin@integrationtestrelorgna40.org
+    expect(output).to.match(/sfdx force:package1:version:create:get -i 0HD.{15} -u/);
     // ensure the package has uploaded by waiting for the package report to be done
     uploadRequestId = /0HD\w*/.exec(output)[0];
     await pollUntilComplete(uploadRequestId);
   });
 
   it(`should create a new 1gp package version for package id ${packageId} (json)`, async () => {
-    const command = `force:package1:beta:version:create -n 1gpPackageNUT -i ${packageId} --json -u 1gp`;
+    const command = `force:package1:version:create -n 1gpPackageNUT -i ${packageId} --json -u 1gp`;
     const output = execCmd<PackageUploadRequest>(command, { ensureExitCode: 0 }).jsonOutput.result;
     expect(output.Status).to.equal('QUEUED');
     expect(output.Id).to.be.a('string');
@@ -99,13 +99,13 @@ describe('package1:version:create', () => {
 
   describe('package1:version:create:get', () => {
     it('will get the result (human)', () => {
-      const command = `force:package1:beta:version:create:get -i ${uploadRequestId} -u 1gp`;
+      const command = `force:package1:version:create:get -i ${uploadRequestId} -u 1gp`;
       const result = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
       expect(result).to.match(/Successfully uploaded package \[04t.{15}]/);
     });
 
     it('will get the result (json)', () => {
-      const command = `force:package1:beta:version:create:get -i ${uploadRequestId} -u 1gp --json`;
+      const command = `force:package1:version:create:get -i ${uploadRequestId} -u 1gp --json`;
       const result = execCmd<PackageUploadRequest>(command, { ensureExitCode: 0 }).jsonOutput.result;
       expect(result).to.have.all.keys(
         'Id',

--- a/test/commands/force/package1/versionCreate.test.ts
+++ b/test/commands/force/package1/versionCreate.test.ts
@@ -10,7 +10,7 @@ import { TestContext } from '@salesforce/core/lib/testSetup';
 import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { Config } from '@oclif/core';
 import { assert, expect } from 'chai';
-import { Package1VersionCreateCommand } from '../../../../src/commands/force/package1/beta/version/create';
+import { Package1VersionCreateCommand } from '../../../../src/commands/force/package1/version/create';
 
 describe('force:package1:version:create', () => {
   const $$ = new TestContext();

--- a/test/commands/force/package1/versionCreate.test.ts
+++ b/test/commands/force/package1/versionCreate.test.ts
@@ -69,7 +69,7 @@ describe('force:package1:version:create', () => {
     expect(result.Status).to.equal('QUEUED');
     expect(uxStub.callCount).to.equal(1);
     expect(uxStub.firstCall.args[0]).to.include(
-      `PackageUploadRequest has been enqueued. You can query the status using${os.EOL}sfdx force:package1:beta:version:create:get -i 0HD4p000000blUvGXX -u test@user.com`
+      `PackageUploadRequest has been enqueued. You can query the status using${os.EOL}sfdx force:package1:version:create:get -i 0HD4p000000blUvGXX -u test@user.com`
     );
   });
 

--- a/test/commands/force/package1/versionCreateGet.test.ts
+++ b/test/commands/force/package1/versionCreateGet.test.ts
@@ -9,7 +9,7 @@ import { TestContext } from '@salesforce/core/lib/testSetup';
 import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { Config } from '@oclif/core';
 import { assert, expect } from 'chai';
-import { Package1VersionCreateGetCommand } from '../../../../src/commands/force/package1/beta/version/create/get';
+import { Package1VersionCreateGetCommand } from '../../../../src/commands/force/package1/version/create/get';
 
 describe('force:package1:version:create:get', () => {
   const $$ = new TestContext();

--- a/test/commands/force/package1/versionDisplay.nut.ts
+++ b/test/commands/force/package1/versionDisplay.nut.ts
@@ -26,7 +26,7 @@ describe('package1:version:display', () => {
   });
 
   it('should list 1gp packages in dev hub - human readable results', () => {
-    const command = `force:package1:beta:version:display -i ${packageVersionId} -u ${session.hubOrg.username}`;
+    const command = `force:package1:version:display -i ${packageVersionId} -u ${session.hubOrg.username}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.match(
       /MetadataPackageVersionId\s+?MetadataPackageId\s+?Name\s+?Version\s+?ReleaseState\s+?BuildNumber/
@@ -35,27 +35,27 @@ describe('package1:version:display', () => {
 
   it('should list 1gp packages in dev hub - human readable results - no results', () => {
     // fake package ID
-    const command = `force:package1:beta:version:display -i 04t46000001ZfaXXXX -u ${session.hubOrg.username}`;
+    const command = `force:package1:version:display -i 04t46000001ZfaXXXX -u ${session.hubOrg.username}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.contain('No results found');
   });
 
   it('should validate packageversionid flag (too short)', () => {
     // fake package ID - too short
-    const command = `force:package1:beta:version:display -i 04t46000001Zfa -u ${session.hubOrg.username}`;
+    const command = `force:package1:version:display -i 04t46000001Zfa -u ${session.hubOrg.username}`;
     const output = execCmd(command, { ensureExitCode: 1 }).shellOutput.stderr;
     expect(output).to.contain('Verify that you entered a valid package version ID (starts with 04t) and try again.');
   });
 
   it("should validate packageversionid flag (doesn't start with 04t)", () => {
     // fake package ID - not an 04t package
-    const command = `force:package1:beta:version:display -i 05t46000001ZfaAAAS -u ${session.hubOrg.username}`;
+    const command = `force:package1:version:display -i 05t46000001ZfaAAAS -u ${session.hubOrg.username}`;
     const output = execCmd(command, { ensureExitCode: 1 }).shellOutput.stderr;
     expect(output).to.contain('Verify that you entered a valid package version ID (starts with 04t) and try again.');
   });
 
   it('should list 1gp packages in dev hub - json', () => {
-    const command = `force:package1:beta:version:display -i ${packageVersionId} -u ${session.hubOrg.username} --json`;
+    const command = `force:package1:version:display -i ${packageVersionId} -u ${session.hubOrg.username} --json`;
     const output = execCmd<Package1Display[]>(command, { ensureExitCode: 0 }).jsonOutput.result[0];
     expect(output).to.have.keys(
       'MetadataPackageVersionId',

--- a/test/commands/force/package1/versionList.nut.ts
+++ b/test/commands/force/package1/versionList.nut.ts
@@ -26,7 +26,7 @@ describe('package1:version:list', () => {
   });
 
   it('should list all 1gp packages in dev hub - human readable results', () => {
-    const command = `force:package1:beta:version:list  -u ${session.hubOrg.username}`;
+    const command = `force:package1:version:list  -u ${session.hubOrg.username}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.match(
       /MetadataPackageVersionId\s+?MetadataPackageId\s+?Name\s+?Version\s+?ReleaseState\s+?BuildNumber/
@@ -34,7 +34,7 @@ describe('package1:version:list', () => {
   });
 
   it('should list 1gp packages in dev hub - json', () => {
-    const command = `force:package1:beta:version:list -u ${session.hubOrg.username} --json`;
+    const command = `force:package1:version:list -u ${session.hubOrg.username} --json`;
     const output = execCmd<Package1Display[]>(command, { ensureExitCode: 0 }).jsonOutput.result[0];
     expect(output).to.have.keys(
       'MetadataPackageVersionId',
@@ -52,12 +52,12 @@ describe('package1:version:list', () => {
   });
 
   before(() => {
-    const command = `force:package1:beta:version:list -u ${session.hubOrg.username} --json`;
+    const command = `force:package1:version:list -u ${session.hubOrg.username} --json`;
     packageId = execCmd<Package1Display[]>(command, { ensureExitCode: 0 }).jsonOutput.result[0].MetadataPackageId;
   });
 
   it('should list all 1gp related to the package id - human readable results', () => {
-    const command = `force:package1:beta:version:list -i ${packageId} -u ${session.hubOrg.username}`;
+    const command = `force:package1:version:list -i ${packageId} -u ${session.hubOrg.username}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.match(
       /MetadataPackageVersionId\s+?MetadataPackageId\s+?Name\s+?Version\s+?ReleaseState\s+?BuildNumber/
@@ -66,27 +66,27 @@ describe('package1:version:list', () => {
 
   it('should list 1gp packages in dev hub related to the package id - human readable results - no results', () => {
     // fake package ID
-    const command = `force:package1:beta:version:list -i 03346000000MrC0AXX -u ${session.hubOrg.username}`;
+    const command = `force:package1:version:list -i 03346000000MrC0AXX -u ${session.hubOrg.username}`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output.trim()).to.contain('No Results Found');
   });
 
   it("should validate packageversionid flag (doesn't start with 033)", () => {
     // fake package ID - not an 033 package
-    const command = `force:package1:beta:version:list -i 03446000001ZfaAAAS -u ${session.hubOrg.username}`;
+    const command = `force:package1:version:list -i 03446000001ZfaAAAS -u ${session.hubOrg.username}`;
     const output = execCmd(command, { ensureExitCode: 1 }).shellOutput.stderr;
     expect(output).to.contain('Verify that you entered a valid package version ID (starts with 033) and try again.');
   });
 
   it('should validate packageversionid flag (too short)', () => {
     // fake package ID - not an 033 package
-    const command = `force:package1:beta:version:list -i 03346000001Zfa -u ${session.hubOrg.username}`;
+    const command = `force:package1:version:list -i 03346000001Zfa -u ${session.hubOrg.username}`;
     const output = execCmd(command, { ensureExitCode: 1 }).shellOutput.stderr;
     expect(output).to.contain('Verify that you entered a valid package version ID (starts with 033) and try again.');
   });
 
   it('should list 1gp packages in dev hub related to the package id - json', () => {
-    const command = `force:package1:beta:version:list -i ${packageId} -u ${session.hubOrg.username} --json`;
+    const command = `force:package1:version:list -i ${packageId} -u ${session.hubOrg.username} --json`;
     const output = execCmd<Package1Display[]>(command, { ensureExitCode: 0 }).jsonOutput.result[0];
     expect(output).to.have.keys(
       'MetadataPackageVersionId',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,7 +1067,7 @@
     "@salesforce/ts-types" "^1.7.1"
     chalk "^2.4.2"
 
-"@salesforce/core@^3.15.5", "@salesforce/core@^3.32.11", "@salesforce/core@^3.32.12", "@salesforce/core@^3.32.6", "@salesforce/core@^3.32.8":
+"@salesforce/core@^3.15.5", "@salesforce/core@^3.32.11", "@salesforce/core@^3.32.12", "@salesforce/core@^3.32.6":
   version "3.32.12"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.32.12.tgz#853cc5b6a5f95d4896b2d34a40a6042ef9aa6d2c"
   integrity sha512-27rqSiQWul7b/OkJs19FYDv2M/S4oI4efiGv+6sR7UWv7D7CG1P+0XpgLS3d9xRYF30h98n6VQr4W2a+BWFRvA==
@@ -1143,16 +1143,16 @@
     shx "^0.3.3"
     tslib "^2.2.0"
 
-"@salesforce/packaging@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-1.1.3.tgz#0730a1fcdd34eda9b12a6224e783193ebc9b362a"
-  integrity sha512-OkoYjL5ZN85yFSqY1mL8XJcU/LzcfLMgzSuVaj1EAsu0zCQUM/Qe+YBlerhXGW5RTSexHtpFFwaiZ3wNEOebAg==
+"@salesforce/packaging@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-1.1.6.tgz#79fd4258d8d7455d0b0b07471e5daac1506582cc"
+  integrity sha512-za5Ay/c6pxMU62YcHihhmI/bkCYrD22XaIAAQniDCkIfYr3P+uuCPOeNba/aR//uwZ6DRfQImOU1fmW+5PXFpg==
   dependencies:
-    "@oclif/core" "^1.20.4"
+    "@oclif/core" "^1.22.0"
     "@salesforce/core" "^3.32.11"
     "@salesforce/kit" "^1.8.0"
     "@salesforce/schemas" "^1.4.0"
-    "@salesforce/source-deploy-retrieve" "^7.5.13"
+    "@salesforce/source-deploy-retrieve" "^7.5.19"
     "@salesforce/ts-types" "^1.7.1"
     "@xmldom/xmldom" "^0.8.6"
     debug "^4.3.4"
@@ -1215,21 +1215,21 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.4.0.tgz#7dff427c8059895d8108176047aee600703c82d6"
   integrity sha512-BJ25uphssN42Zy6kksheFHMTLiR98AAHe/Wxnv0T4dYxtrEbUjSXVAGKZqfewJPFXA4xB5gxC+rQZtfz6xKCFg==
 
-"@salesforce/source-deploy-retrieve@^7.5.13":
-  version "7.5.18"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-7.5.18.tgz#68fc042b2819427fabb8823b81f78993d76234b1"
-  integrity sha512-14JJbWvWxPhjbbbhPdYpBADe6gr9zeqrX+r6DZ3mEjLYx59Hn3RWueBLFdoDYHViMlmHnBIil65wgjhTJ10WdQ==
+"@salesforce/source-deploy-retrieve@^7.5.19":
+  version "7.5.22"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-7.5.22.tgz#6825f75c6a1d762149f9e330683182d8f3003110"
+  integrity sha512-+ZDCj5zULWs6lj2B978XKt8pj1ondHoxqSh7O3UpyyjAppCnrQGGrduoAzycjrSVmGRXkwrrTybLzA8zil9zsw==
   dependencies:
-    "@salesforce/core" "^3.32.8"
+    "@salesforce/core" "^3.32.12"
     "@salesforce/kit" "^1.8.0"
     "@salesforce/ts-types" "^1.7.1"
     archiver "^5.3.1"
     fast-xml-parser "^3.21.1"
-    got "^11.8.5"
+    got "^11.8.6"
     graceful-fs "^4.2.10"
-    ignore "^5.2.1"
+    ignore "^5.2.4"
     mime "2.6.0"
-    minimatch "^5.1.0"
+    minimatch "^5.1.2"
     proxy-agent "^5.0.0"
     proxy-from-env "^1.1.0"
     unzipper "0.10.11"
@@ -4153,7 +4153,7 @@ globby@^11, globby@^11.0.1, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-got@^11, got@^11.8.5:
+got@^11, got@^11.8.6:
   version "11.8.6"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
   integrity sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==
@@ -4462,7 +4462,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4, ignore@^5.2.0, ignore@^5.2.1:
+ignore@^5.1.1, ignore@^5.1.4, ignore@^5.2.0, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
@@ -5521,6 +5521,13 @@ minimatch@^5.0.1, minimatch@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.0.tgz#1717b464f4971b144f6aabe8f2d0b8e4511e09c7"
   integrity sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.2.tgz#0939d7d6f0898acbd1508abe534d1929368a8fff"
+  integrity sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==
   dependencies:
     brace-expansion "^2.0.1"
 


### PR DESCRIPTION
### What does this PR do?
All packaging commands from this plugin will become the GA version in the CLI next release.  The commands are aliased so that executing the beta version of them will continue to work.  I.e., executing `force:package:beta:create` will execute the same command (from this plugin) as executing `force:package:create`.

### What issues does this PR fix or reference?
@W-10833244@