### PR TITLE
feat: adds the seedMetadata command line parameter to the convert command.

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -49,6 +49,7 @@
       "json",
       "loglevel",
       "package",
+      "seedmetadata",
       "targetdevhubusername",
       "wait"
     ],

--- a/messages/package_convert.md
+++ b/messages/package_convert.md
@@ -65,3 +65,11 @@ the instance where the conversion package version will be created——for examp
 # longInstance
 
 The instance where the conversion package version will be created——for example, NA50.
+
+# seedMetadata
+
+Directory containing metadata to be deployed prior to conversion.
+
+# longSeedMetadata
+
+The directory containing metadata that will be deployed on the build org prior to attempting conversion.

--- a/src/commands/force/package/convert.ts
+++ b/src/commands/force/package/convert.ts
@@ -66,6 +66,11 @@ export class PackageConvert extends SfdxCommand {
       longDescription: messages.getMessage('longInstance'),
       hidden: true,
     }),
+    seedmetadata: flags.directory({
+      char: 'm',
+      description: messages.getMessage('seedMetadata'),
+      longDescription: messages.getMessage('longSeedMetadata'),
+    }),
   };
 
   public async run(): Promise<PackageVersionCreateRequestResult> {
@@ -102,6 +107,7 @@ export class PackageConvert extends SfdxCommand {
         definitionfile: this.flags.definitionfile as string,
         installationKeyBypass: this.flags.installationkeybypass as boolean,
         buildInstance: this.flags.buildinstance as string,
+        seedMetadata: this.flags.seedmetadata as string,
       },
       project
     );


### PR DESCRIPTION
### What does this PR do?
Adds an optional command line parameter to the convert command so unpackageable metadata can be pushed to the build org that the packaged metadata depends on, such as StandardValueSets.

### What issues does this PR fix or reference?
@W-12204966@