### PR TITLE
feat: adds the seedMetadata command line parameter to the convert command

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -49,6 +49,7 @@
       "json",
       "loglevel",
       "package",
+      "seed-metadata",
       "target-hub-org",
       "wait"
     ],

--- a/messages/package_convert.md
+++ b/messages/package_convert.md
@@ -65,3 +65,11 @@ Instance where the conversion package version will be created, such as NA50.
 # in-progress
 
 Request in progress. Will wait a total of %s more seconds before timing out. Current Status='%s'
+
+# flags.seed-metadata.summary
+
+Directory containing metadata to be deployed prior to conversion.
+
+# flags.seed-metadata.description
+
+The directory containing metadata that will be deployed on the build org prior to attempting conversion.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@oclif/core": "^1.25.0",
     "@salesforce/core": "^3.33.0",
     "@salesforce/kit": "^1.8.3",
-    "@salesforce/packaging": "^1.1.11",
+    "@salesforce/packaging": "^1.2.0",
     "@salesforce/sf-plugins-core": "^1.22.1",
     "chalk": "^4.1.2",
     "tslib": "^2"

--- a/src/commands/package/convert.ts
+++ b/src/commands/package/convert.ts
@@ -82,6 +82,11 @@ export class PackageConvert extends SfCommand<PackageVersionCreateRequestResult>
       summary: messages.getMessage('flags.build-instance.summary'),
       hidden: true,
     }),
+    'seed-metadata': Flags.directory({
+      char: 'm',
+      summary: messages.getMessage('flags.seed-metadata.summary'),
+      description: messages.getMessage('flags.seed-metadata.description'),
+    }),
   };
 
   public async run(): Promise<PackageVersionCreateRequestResult> {
@@ -117,6 +122,7 @@ export class PackageConvert extends SfCommand<PackageVersionCreateRequestResult>
         definitionfile: flags['definition-file'] as string,
         installationKeyBypass: flags['installation-key-bypass'],
         buildInstance: flags['build-instance'] as string,
+        seedMetadata: flags['seed-metadata'] as string,
       },
       project
     );


### PR DESCRIPTION


What does this PR do?

Adds an optional command line parameter to the convert command so unpackageable metadata can be pushed to the build org that the packaged metadata depends on, such as StandardValueSets.
What issues does this PR fix or reference?

@W-12204966@
