### PR TITLE
fix: remove unused token

### DIFF
--- a/src/commands/package/version/update.ts
+++ b/src/commands/package/version/update.ts
@@ -77,7 +77,7 @@ export class PackageVersionUpdateCommand extends SfCommand<PackageSaveResult> {
       Tag: flags.tag,
     });
 
-    this.logSuccess(messages.getMessage('success', [result.id]));
+    this.logSuccess(messages.getMessage('success'));
 
     return result;
   }


### PR DESCRIPTION
### What does this PR do?
remove an unused message token.  As is, the pvId is gonna hang out weirdly on the end of the line.  If we wanted to show it to the user, maybe use a `%s` placeholder and better wording?

### What issues does this PR fix or reference?
I found it while testing out @W-12444613@
