### PR TITLE
fix: verify the SPV is availble to query, before checking deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@oclif/core": "^1.25.0",
     "@salesforce/core": "^3.33.0",
     "@salesforce/kit": "^1.8.3",
-    "@salesforce/packaging": "^1.1.11",
+    "@salesforce/packaging": "^1.2.3",
     "@salesforce/sf-plugins-core": "^1.22.1",
     "chalk": "^4.1.2",
     "tslib": "^2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^3.2.18",
     "@oclif/plugin-version": "^1.2.0",
-    "@salesforce/cli-plugins-testkit": "^3.2.18",
+    "@salesforce/cli-plugins-testkit": "^3.2.20",
     "@salesforce/dev-config": "^3.1.0",
     "@salesforce/dev-scripts": "^3.1.1",
     "@salesforce/plugin-auth": "^2.3.12",

--- a/src/commands/package/install.ts
+++ b/src/commands/package/install.ts
@@ -135,7 +135,7 @@ export class Install extends SfCommand<PackageInstallRequest> {
       this.warn(warningMsg);
     });
 
-    if (flags['publish-wait']) {
+    if (flags['publish-wait']?.milliseconds > 0) {
       let timeThen = Date.now();
       // waiting for publish to finish
       let remainingTime = flags['publish-wait'];
@@ -155,19 +155,17 @@ export class Install extends SfCommand<PackageInstallRequest> {
         }
       );
 
-      if (flags['publish-wait'].milliseconds > 0) {
-        this.spinner.start(
-          messages.getMessage('packagePublishWaitingStatus', [remainingTime.minutes, 'Querying Status'])
-        );
+      this.spinner.start(
+        messages.getMessage('packagePublishWaitingStatus', [remainingTime.minutes, 'Querying Status'])
+      );
 
-        await this.subscriberPackageVersion.waitForPublish({
-          publishTimeout: flags['publish-wait'],
-          publishFrequency: Duration.seconds(10),
-          installationKey: flags['installation-key'],
-        });
-        // need to stop the spinner to avoid weird behavior with the prompts below
-        this.spinner.stop();
-      }
+      await this.subscriberPackageVersion.waitForPublish({
+        publishTimeout: flags['publish-wait'],
+        publishFrequency: Duration.seconds(10),
+        installationKey: flags['installation-key'],
+      });
+      // need to stop the spinner to avoid weird behavior with the prompts below
+      this.spinner.stop();
     }
 
     // If the user has specified --upgradetype Delete, then prompt for confirmation
@@ -183,7 +181,6 @@ export class Install extends SfCommand<PackageInstallRequest> {
     let installOptions: Optional<PackageInstallOptions>;
     if (flags.wait) {
       installOptions = {
-        publishTimeout: flags['publish-wait'],
         pollingTimeout: flags.wait,
       };
       let remainingTime = flags.wait;

--- a/src/commands/package/install.ts
+++ b/src/commands/package/install.ts
@@ -135,7 +135,7 @@ export class Install extends SfCommand<PackageInstallRequest> {
       this.warn(warningMsg);
     });
 
-    if (flags.wait) {
+    if (flags['publish-wait']) {
       let timeThen = Date.now();
       // waiting for publish to finish
       let remainingTime = flags['publish-wait'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1081,12 +1081,12 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/cli-plugins-testkit@^3.2.18":
-  version "3.2.18"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-3.2.18.tgz#6c2857cef50a0035205a4150c6d609f36e3b0fae"
-  integrity sha512-tfm1lYPYcOsx9+ELUx+b9ZbAD5mOIhtvGjqpG3/NG1jeghLNPjbDDX6bL1ottw/+mYBVymIrj1krhKxOUpqJCw==
+"@salesforce/cli-plugins-testkit@^3.2.20":
+  version "3.2.20"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-3.2.20.tgz#15f0e3a50e2242c482bb89fb18464473f8cc2cbc"
+  integrity sha512-EOKTZQrTiyZWPUKwbjZTJf9UvLlUrnXGN2qDgi65S7OH4W/bR1syRlrVDJ8w/F5mSqKaExhGGoFviycRrWrW8g==
   dependencies:
-    "@salesforce/core" "^3.32.12"
+    "@salesforce/core" "^3.33.1"
     "@salesforce/kit" "^1.8.0"
     "@salesforce/ts-types" "^1.7.2"
     "@types/shelljs" "^0.8.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,23 +1184,23 @@
     shx "^0.3.3"
     tslib "^2.2.0"
 
-"@salesforce/packaging@^1.1.11":
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-1.1.12.tgz#c8b3b6a4567b2c7c366e11010a8776a3e188e832"
-  integrity sha512-zrGvDcUn5gxT0M1uFx/B4GkXKZpxigaDVKYYD2ld2oVDw3emlpKEoVKE4XE/9vSqdkwDWRLSl+zBGH16biJKLw==
+"@salesforce/packaging@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-1.2.3.tgz#c363c23613979e278b7e3c795a7e816273d38de4"
+  integrity sha512-wdSwXDi/8pDQoLfT7SN/RWbFlsZMNhksHazt6Uzg4ewiwKtq0cDSR9uo3r/uTYmhPbVQ423I/drawStI9P1U2w==
   dependencies:
     "@oclif/core" "^1.25.0"
     "@salesforce/core" "^3.32.11"
-    "@salesforce/kit" "^1.8.0"
-    "@salesforce/schemas" "^1.4.0"
-    "@salesforce/source-deploy-retrieve" "^7.5.19"
+    "@salesforce/kit" "^1.8.3"
+    "@salesforce/schemas" "^1.5.0"
+    "@salesforce/source-deploy-retrieve" "^7.7.5"
     "@salesforce/ts-types" "^1.7.1"
     "@xmldom/xmldom" "^0.8.6"
     debug "^4.3.4"
     globby "^11"
     graphology "^0.25.1"
     graphology-traversal "^0.3.1"
-    graphology-types "^0.24.5"
+    graphology-types "^0.24.7"
     js2xmlparser "^4.0.2"
     jsforce "2.0.0-beta.19"
     jszip "^3.10.1"
@@ -1259,6 +1259,11 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.4.0.tgz#7dff427c8059895d8108176047aee600703c82d6"
   integrity sha512-BJ25uphssN42Zy6kksheFHMTLiR98AAHe/Wxnv0T4dYxtrEbUjSXVAGKZqfewJPFXA4xB5gxC+rQZtfz6xKCFg==
 
+"@salesforce/schemas@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.5.0.tgz#8bfe2cb5d7cb29d3394b3b9cfb71bb527009c82c"
+  integrity sha512-EKFBURBuON7cj8XZCW+ybeSRRw7wUP1XUXZVHzFgx8KiYmSeGiRHBYbDjQOsQMho2uOLsTozMPEt2ehYnji0YA==
+
 "@salesforce/sf-plugins-core@^1.21.5", "@salesforce/sf-plugins-core@^1.22.1":
   version "1.22.2"
   resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-1.22.2.tgz#56aa9c490a64a53142160eb0b67bc32331ad0674"
@@ -1271,13 +1276,13 @@
     chalk "^4"
     inquirer "^8.2.5"
 
-"@salesforce/source-deploy-retrieve@^7.5.19":
-  version "7.7.5"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-7.7.5.tgz#4eb64f02d4759f98e1e64187a081c472ebe8a2ae"
-  integrity sha512-zkGpbvTVr2nBJfbTxShFfaa4DAOvbXiaaWjZg0oVLUDoAQh+uQKX4aPdsXqJR4pKdQR8u1JwEV7TlR1f5gMCrg==
+"@salesforce/source-deploy-retrieve@^7.7.5":
+  version "7.7.6"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-7.7.6.tgz#57fc93ca4f14bf27e7db5fd3759cc290bc0d4eed"
+  integrity sha512-AIMMxGXnzFmuoUnnM0Kum6Av9vMtX9Yq7qkBMVaFFubjAj29vU4pv+JJ1CIsITVrqNNd9Hi09TVQtw3rQvsqyQ==
   dependencies:
     "@salesforce/core" "^3.32.13"
-    "@salesforce/kit" "^1.8.0"
+    "@salesforce/kit" "^1.8.3"
     "@salesforce/ts-types" "^1.7.2"
     archiver "^5.3.1"
     fast-xml-parser "^3.21.1"
@@ -4349,7 +4354,7 @@ graphology-traversal@^0.3.1:
     graphology-indices "^0.17.0"
     graphology-utils "^2.0.0"
 
-graphology-types@^0.24.5:
+graphology-types@^0.24.7:
   version "0.24.7"
   resolved "https://registry.yarnpkg.com/graphology-types/-/graphology-types-0.24.7.tgz#7d630a800061666bfa70066310f56612e08b7bee"
   integrity sha512-tdcqOOpwArNjEr0gNQKCXwaNCWnQJrog14nJNQPeemcLnXQUUGrsCWpWkVKt46zLjcS6/KGoayeJfHHyPDlvwA==


### PR DESCRIPTION
### What does this PR do?
when `--publish-wait` and `--wait` are provided, it will ensure the SPV is replicated, before checking for external sites or other prompts that require verification

### What issues does this PR fix or reference?
requires: https://github.com/forcedotcom/packaging/pull/205
@W-12432030@
fixes:https://github.com/forcedotcom/cli/issues/1895