### PR TITLE
@W-12394717@ Optionally skip install handlers during installation

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -91,6 +91,7 @@
       "package",
       "publishwait",
       "securitytype",
+      "skiphandlers",
       "targetusername",
       "upgradetype",
       "wait"

--- a/messages/package_install.md
+++ b/messages/package_install.md
@@ -147,3 +147,11 @@ Available for installation
 # unavailableForInstallation
 
 Unavailable for installation
+
+# skipHandlersDescription
+
+Skip the feature enforcement install handler
+
+# skipHandlersDescriptionLong
+
+Allows installer to optionally skip the install handler for org feature enforcement in order to decrease overall installation time.

--- a/messages/package_install.md
+++ b/messages/package_install.md
@@ -150,8 +150,8 @@ Unavailable for installation
 
 # skipHandlersDescription
 
-Skip the feature enforcement install handler
+Skip install handlers (available handlers: FeatureEnforcement)
 
 # skipHandlersDescriptionLong
 
-Allows installer to optionally skip the install handler for org feature enforcement in order to decrease overall installation time.
+Allows the installer of a package to optionally skip install handlers in order to decrease overall installation time (available handlers: FeatureEnforcement)

--- a/src/commands/force/package/beta/install.ts
+++ b/src/commands/force/package/beta/install.ts
@@ -26,7 +26,6 @@ const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_
 // maps of command flag values to PackageInstallRequest values
 const securityType = { AllUsers: 'full', AdminsOnly: 'none' };
 const upgradeType = { Delete: 'delete-only', DeprecateOnly: 'deprecate-only', Mixed: 'mixed-mode' };
-const skipHandlersType = { FeatureEnforcement: 'FeatureEnforcement' };
 
 export class Install extends SfdxCommand {
   public static readonly description = messages.getMessage('cliDescription');
@@ -82,7 +81,7 @@ export class Install extends SfdxCommand {
       default: 'Mixed',
       options: ['DeprecateOnly', 'Mixed', 'Delete'],
     }),
-    skiphandlers: flags.boolean({
+    skiphandlers: flags.array({
       char: 'l',
       description: messages.getMessage('skipHandlersDescription'),
       longDescription: messages.getMessage('skipHandlersDescriptionLong'),
@@ -141,7 +140,7 @@ export class Install extends SfdxCommand {
       SecurityType: securityType[this.flags.securitytype as string] as PackageInstallCreateRequest['SecurityType'],
       SkipHandlers: (this.flags.skiphandlers === undefined
         ? this.flags.skiphandlers
-        : skipHandlersType['FeatureEnforcement']) as PackageInstallCreateRequest['SkipHandlers'],
+        : String(this.flags.skiphandlers)) as PackageInstallCreateRequest['SkipHandlers'],
       UpgradeType: upgradeType[this.flags.upgradetype as string] as PackageInstallCreateRequest['UpgradeType'],
     };
 

--- a/src/commands/force/package/beta/install.ts
+++ b/src/commands/force/package/beta/install.ts
@@ -26,6 +26,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_
 // maps of command flag values to PackageInstallRequest values
 const securityType = { AllUsers: 'full', AdminsOnly: 'none' };
 const upgradeType = { Delete: 'delete-only', DeprecateOnly: 'deprecate-only', Mixed: 'mixed-mode' };
+const skipHandlersType = { FeatureEnforcement: 'FeatureEnforcement' };
 
 export class Install extends SfdxCommand {
   public static readonly description = messages.getMessage('cliDescription');
@@ -81,6 +82,12 @@ export class Install extends SfdxCommand {
       default: 'Mixed',
       options: ['DeprecateOnly', 'Mixed', 'Delete'],
     }),
+    skiphandlers: flags.boolean({
+      char: 'l',
+      description: messages.getMessage('skipHandlersDescription'),
+      longDescription: messages.getMessage('skipHandlersDescriptionLong'),
+      hidden: true,
+    }),
   };
 
   private connection: Connection;
@@ -132,6 +139,9 @@ export class Install extends SfdxCommand {
       Password: this.flags.installationkey as PackageInstallCreateRequest['Password'],
       ApexCompileType: this.flags.apexcompile as PackageInstallCreateRequest['ApexCompileType'],
       SecurityType: securityType[this.flags.securitytype as string] as PackageInstallCreateRequest['SecurityType'],
+      SkipHandlers: (this.flags.skiphandlers === undefined
+        ? this.flags.skiphandlers
+        : skipHandlersType['FeatureEnforcement']) as PackageInstallCreateRequest['SkipHandlers'],
       UpgradeType: upgradeType[this.flags.upgradetype as string] as PackageInstallCreateRequest['UpgradeType'],
     };
 

--- a/test/commands/force/package/install.test.ts
+++ b/test/commands/force/package/install.test.ts
@@ -338,7 +338,7 @@ describe('force:package:install', () => {
         'AllUsers',
         '-t',
         'DeprecateOnly',
-        '-l',
+        '-l FeatureEnforcement',
       ]);
 
       expect(result).to.deep.equal(pkgInstallRequest);

--- a/test/commands/force/package/install.test.ts
+++ b/test/commands/force/package/install.test.ts
@@ -53,6 +53,7 @@ describe('force:package:install', () => {
     EnableRss: false,
     UpgradeType: 'mixed-mode',
     ApexCompileType: 'all',
+    SkipHandlers: undefined,
     Status: 'IN_PROGRESS',
     Errors: null,
   };
@@ -61,6 +62,7 @@ describe('force:package:install', () => {
     SubscriberPackageVersionKey: myPackageVersion04t,
     Password: undefined,
     ApexCompileType: 'all',
+    SkipHandlers: undefined,
     SecurityType: 'none',
     UpgradeType: 'mixed-mode',
   };
@@ -316,11 +318,12 @@ describe('force:package:install', () => {
       expect(installStub.args[0][0]).to.deep.equal(expectedCreateRequest);
     });
 
-    it('sets PackageInstallRequest values for securityType, upgradeType, apexCompileType', async () => {
+    it('sets PackageInstallRequest values for securityType, upgradeType, apexCompileType, SkipHandlers', async () => {
       const overrides = {
         ApexCompileType: 'package',
         SecurityType: 'full',
         UpgradeType: 'deprecate-only',
+        SkipHandlers: 'FeatureEnforcement',
       };
       const expectedCreateRequest = Object.assign({}, pkgInstallCreateRequest, overrides);
       installStub = stubMethod($$.SANDBOX, SubscriberPackageVersion.prototype, 'install').resolves(pkgInstallRequest);
@@ -335,6 +338,7 @@ describe('force:package:install', () => {
         'AllUsers',
         '-t',
         'DeprecateOnly',
+        '-l',
       ]);
 
       expect(result).to.deep.equal(pkgInstallRequest);

--- a/test/commands/force/package/installReport.test.ts
+++ b/test/commands/force/package/installReport.test.ts
@@ -41,6 +41,7 @@ describe('force:package:install:report', () => {
     EnableRss: false,
     UpgradeType: 'mixed-mode',
     ApexCompileType: 'all',
+    SkipHandlers: null,
     Status: 'IN_PROGRESS',
     Errors: null,
   };


### PR DESCRIPTION
@W-12394717@

### What does this PR do?
Provide a new option to skip install handlers during package installation. The "FeatureEnforcement" handler is the only available option for this initial release.

### What issues does this PR fix or reference?
The feature helps reduce installation times in certain cases where install handlers can be safely skipped. The FeatureEnforcement install handler creates guardrails in the subscriber org to prevent the admin from turning off org features required by the package.
