### PR TITLE
chore: split package and package1 nuts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,4 @@ jobs:
       fail-fast: false
     with:
       os: ${{ matrix.os }}
+      command: ${{ matrix.command }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+        command:
+          - 'yarn test:nuts:package'
+          - 'yarn test:nuts:package1'
       fail-fast: false
     with:
       os: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
     "test:command-reference": "./bin/dev commandreference:generate --erroronwarnings",
     "test:deprecation-policy": "./bin/dev snapshot:compare",
     "test:nuts": "nyc mocha \"**/*.nut.ts\" --slow 4500 --timeout 1800000 --parallel",
-    "test:nuts:package1": "nyc mocha \"**/package1/*.nut.ts\" --slow 4500 --timeout 600000 --parallel",
+    "test:nuts:package": "nyc mocha \"test/commands/package/*.nut.ts\" --slow 4500 --timeout 600000 --parallel",
+    "test:nuts:package1": "nyc mocha \"test/commands/package1/*.nut.ts\" --slow 4500 --timeout 600000 --parallel",
     "test:json-schema": "./bin/dev schema:compare",
     "version": "oclif readme"
   },

--- a/test/commands/package/packageVersion.nut.ts
+++ b/test/commands/package/packageVersion.nut.ts
@@ -340,6 +340,7 @@ describe('package:version:*', () => {
         'IsPasswordProtected',
         'IsReleased',
         'CreatedDate',
+        'Language',
         'LastModifiedDate',
         'InstallUrl',
         'CodeCoverage',


### PR DESCRIPTION
### What does this PR do?
Create yarn scripts to run package and package1 NUTs independently and change the GHA workflow to use them.

### What issues does this PR fix or reference?
@W-12567087@