### PR TITLE
test: packaging nuts assertions allow sf OR sfdx

### DIFF
--- a/test/commands/package/install.nut.ts
+++ b/test/commands/package/install.nut.ts
@@ -21,8 +21,6 @@ describe('package install', () => {
       devhubAuthStrategy: 'AUTO',
       scratchOrgs: [
         {
-          executable: 'sfdx',
-          duration: 1,
           setDefault: true,
           config: path.join('config', 'project-scratch-def.json'),
         },

--- a/test/commands/package/packageVersion.nut.ts
+++ b/test/commands/package/packageVersion.nut.ts
@@ -54,7 +54,7 @@ describe('package:version:*', () => {
       // eslint-disable-next-line no-console
       console.log(result);
       expect(result).to.include("Package version creation request status is '");
-      expect(result).to.match(/Run "sfdx package:version:create:report -i 08c.{15}" to query for status\./);
+      expect(result).to.match(/Run "sfd?x? package:version:create:report -i 08c.{15}" to query for status\./);
     });
 
     // package:version:create --wait --json is tested in versionPromoteUpdate.nut.ts
@@ -68,7 +68,7 @@ describe('package:version:*', () => {
       expect(result).to.match(
         /Package Installation URL: https:\/\/login.salesforce.com\/packaging\/installPackage\.apexp\?p0=04t.{15}/
       );
-      expect(result).to.match(/As an alternative, you can use the "sfdx package:install" command\./);
+      expect(result).to.match(/As an alternative, you can use the "sfd?x? package:install" command\./);
     });
 
     it('should create a new package version (json)', () => {

--- a/test/commands/package/versionPromoteUpdate.nut.ts
+++ b/test/commands/package/versionPromoteUpdate.nut.ts
@@ -25,8 +25,6 @@ describe('package:version:promote / package:version:update', () => {
       devhubAuthStrategy: 'AUTO',
       scratchOrgs: [
         {
-          executable: 'sfdx',
-          duration: 1,
           setDefault: true,
           config: path.join('config', 'project-scratch-def.json'),
         },

--- a/test/commands/package1/versionCreate.nut.ts
+++ b/test/commands/package1/versionCreate.nut.ts
@@ -9,9 +9,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-import { assert, expect } from 'chai';
+import { assert, expect, config as chaiConfig } from 'chai';
 import { PackagingSObjects } from '@salesforce/packaging';
 import { sleep } from '@salesforce/kit';
+
+chaiConfig.truncateThreshold = 0;
 
 type PackageUploadRequest = PackagingSObjects.PackageUploadRequest;
 
@@ -80,7 +82,7 @@ describe('package1:version:create', () => {
     const command = `package1:version:create -n 1gpPackageNUT -i ${packageId} -o 1gp`;
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.match(/PackageUploadRequest has been enqueued\./);
-    expect(output).to.match(/sfdx package1:version:create:get -i 0HD.{15} -o/);
+    expect(output).to.match(/package1:version:create:get -i 0HD.{15} -o/);
     // ensure the package has uploaded by waiting for the package report to be done
     // @ts-ignore
     uploadRequestId = /0HD\w*/.exec(output)?.at(0);


### PR DESCRIPTION
### What does this PR do?
comands were updated to pass config.bin to the messages

NUTs needed to be updated to not hardcode expectations of `sfdx` in those messages.  

### What issues does this PR fix or reference?

solve https://github.com/salesforcecli/cli/actions/runs/4867876480/jobs/8681253402