### PR TITLE
chore: bump packaging dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@oclif/core": "^2.8.2",
     "@salesforce/core": "^4.0.1",
     "@salesforce/kit": "^3.0.2",
-    "@salesforce/packaging": "^2.0.2",
+    "@salesforce/packaging": "^2.1.2",
     "@salesforce/sf-plugins-core": "^3.0.2",
     "chalk": "^4.1.2",
     "tslib": "^2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,10 +1080,10 @@
     "@salesforce/ts-types" "^2.0.1"
     tslib "^2.5.2"
 
-"@salesforce/packaging@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-2.0.2.tgz#5f922d777ae463d6dc254290936212e728c277db"
-  integrity sha512-2g2bFX1na+Pi0Zyqx1+fucShJabNSjOdnlzuximeIo9w4G4Iro/zHdzHm9/AG3H9jSg7Wq1QSGx4h3BPSozbsA==
+"@salesforce/packaging@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-2.1.2.tgz#3b8b7d7ebe357572beb83b4a7da5881f17d64d7a"
+  integrity sha512-H/XskHCH6qz5jmI7GUe5uridDNtpIlZ1ayGM0dKTuvX6D1KulFydXfJUV3ed+aKg43JRNmf3PUtgCKP4zTSIbw==
   dependencies:
     "@oclif/core" "^2.8.5"
     "@salesforce/core" "^4.0.1"
@@ -1091,7 +1091,7 @@
     "@salesforce/schemas" "^1.5.1"
     "@salesforce/source-deploy-retrieve" "^8.6.0"
     "@salesforce/ts-types" "^2.0.2"
-    "@xmldom/xmldom" "^0.8.7"
+    "@xmldom/xmldom" "^0.8.8"
     debug "^4.3.4"
     globby "^11"
     graphology "^0.25.1"
@@ -1670,10 +1670,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@xmldom/xmldom@^0.8.7":
-  version "0.8.7"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.7.tgz#8b1e39c547013941974d83ad5e9cf5042071a9a0"
-  integrity sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg==
+"@xmldom/xmldom@^0.8.8":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.8.tgz#d0d11511cbc1de77e53342ad1546a4d487d6ea72"
+  integrity sha512-0LNz4EY8B/8xXY86wMrQ4tz6zEHZv9ehFMJPm8u2gq5lQ71cfRKdaKyxfJAx5aUoyzx0qzgURblTisPGgz3d+Q==
 
 JSONStream@^1.0.4:
   version "1.3.5"


### PR DESCRIPTION
### What does this PR do?
Bump `packaging` dependency to 2.1.2 to include recent fixes for `package version retrieve` command.

### What issues does this PR fix or reference?
@W-12557202@