### PR TITLE
Sm/remove-beta

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -17,7 +17,7 @@
       "version",
       "wait"
     ],
-    "alias": ["force:package1:beta:version:create", "force:package1:version:create"],
+    "alias": ["force:package1:version:create"],
     "flagChars": ["d", "i", "k", "m", "n", "o", "p", "r", "v", "w"],
     "flagAliases": [
       "apiversion",
@@ -34,7 +34,7 @@
     "command": "package1:version:create:get",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "request-id", "target-org"],
-    "alias": ["force:package1:beta:version:create:get", "force:package1:version:create:get"],
+    "alias": ["force:package1:version:create:get"],
     "flagChars": ["i", "o"],
     "flagAliases": ["apiversion", "requestid", "targetusername", "u"]
   },
@@ -42,7 +42,7 @@
     "command": "package1:version:display",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "package-version-id", "target-org"],
-    "alias": ["force:package1:beta:version:display", "force:package1:version:display"],
+    "alias": ["force:package1:version:display"],
     "flagChars": ["i", "o"],
     "flagAliases": ["apiversion", "packageversionid", "targetusername", "u"]
   },
@@ -50,7 +50,7 @@
     "command": "package1:version:list",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "package-id", "target-org"],
-    "alias": ["force:package1:beta:version:list", "force:package1:version:list"],
+    "alias": ["force:package1:version:list"],
     "flagChars": ["i", "o"],
     "flagAliases": ["apiversion", "packageid", "targetusername", "u"]
   },
@@ -70,7 +70,7 @@
       "target-dev-hub",
       "wait"
     ],
-    "alias": ["force:package:beta:convert", "force:package:convert"],
+    "alias": ["force:package:convert"],
     "flagChars": ["f", "k", "m", "p", "s", "v", "w", "x"],
     "flagAliases": [
       "apiversion",
@@ -98,7 +98,7 @@
       "path",
       "target-dev-hub"
     ],
-    "alias": ["force:package:beta:create", "force:package:create"],
+    "alias": ["force:package:create"],
     "flagChars": ["d", "e", "n", "o", "r", "t", "v"],
     "flagAliases": [
       "apiversion",
@@ -114,7 +114,7 @@
     "command": "package:delete",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "no-prompt", "package", "target-dev-hub", "undelete"],
-    "alias": ["force:package:beta:delete", "force:package:delete"],
+    "alias": ["force:package:delete"],
     "flagChars": ["n", "p", "v"],
     "flagAliases": ["apiversion", "noprompt", "target-hub-org", "targetdevhubusername"]
   },
@@ -136,7 +136,7 @@
       "upgrade-type",
       "wait"
     ],
-    "alias": ["force:package:beta:install", "force:package:install"],
+    "alias": ["force:package:install"],
     "flagChars": ["a", "b", "k", "l", "o", "p", "r", "s", "t", "w"],
     "flagAliases": [
       "apexcompile",
@@ -154,7 +154,7 @@
     "command": "package:install:report",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "request-id", "target-org"],
-    "alias": ["force:package:beta:install:report", "force:package:install:report"],
+    "alias": ["force:package:install:report"],
     "flagChars": ["i", "o"],
     "flagAliases": ["apiversion", "requestid", "targetusername", "u"]
   },
@@ -162,7 +162,7 @@
     "command": "package:installed:list",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "target-org"],
-    "alias": ["force:package:beta:installed:list", "force:package:installed:list"],
+    "alias": ["force:package:installed:list"],
     "flagChars": ["o"],
     "flagAliases": ["apiversion", "targetusername", "u"]
   },
@@ -170,7 +170,7 @@
     "command": "package:list",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "target-dev-hub", "verbose"],
-    "alias": ["force:package:beta:list", "force:package:list"],
+    "alias": ["force:package:list"],
     "flagChars": ["v"],
     "flagAliases": ["apiversion", "target-hub-org", "targetdevhubusername"]
   },
@@ -178,7 +178,7 @@
     "command": "package:uninstall",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "package", "target-org", "wait"],
-    "alias": ["force:package:beta:uninstall", "force:package:uninstall"],
+    "alias": ["force:package:uninstall"],
     "flagChars": ["o", "p", "w"],
     "flagAliases": ["apiversion", "targetusername", "u"]
   },
@@ -186,7 +186,7 @@
     "command": "package:uninstall:report",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "request-id", "target-org"],
-    "alias": ["force:package:beta:uninstall:report", "force:package:uninstall:report"],
+    "alias": ["force:package:uninstall:report"],
     "flagChars": ["i", "o"],
     "flagAliases": ["apiversion", "requestid", "targetusername", "u"]
   },
@@ -204,7 +204,7 @@
       "package",
       "target-dev-hub"
     ],
-    "alias": ["force:package:beta:update", "force:package:update"],
+    "alias": ["force:package:update"],
     "flagChars": ["d", "n", "o", "p", "v"],
     "flagAliases": ["apiversion", "errornotificationusername", "target-hub-org", "targetdevhubusername"]
   },
@@ -240,7 +240,7 @@
       "version-number",
       "wait"
     ],
-    "alias": ["force:package:beta:version:create", "force:package:version:create"],
+    "alias": ["force:package:version:create"],
     "flagChars": ["a", "b", "c", "d", "e", "f", "j", "k", "n", "p", "r", "s", "t", "v", "w", "x"],
     "flagAliases": [
       "apiversion",
@@ -267,7 +267,7 @@
     "command": "package:version:create:list",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "created-last-days", "json", "loglevel", "status", "target-dev-hub"],
-    "alias": ["force:package:beta:version:create:list", "force:package:version:create:list"],
+    "alias": ["force:package:version:create:list"],
     "flagChars": ["c", "s", "v"],
     "flagAliases": ["apiversion", "createdlastdays", "target-hub-org", "targetdevhubusername"]
   },
@@ -275,7 +275,7 @@
     "command": "package:version:create:report",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "package-create-request-id", "target-dev-hub"],
-    "alias": ["force:package:beta:version:create:report", "force:package:version:create:report"],
+    "alias": ["force:package:version:create:report"],
     "flagChars": ["i", "v"],
     "flagAliases": ["apiversion", "packagecreaterequestid", "target-hub-org", "targetdevhubusername"]
   },
@@ -283,7 +283,7 @@
     "command": "package:version:delete",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "no-prompt", "package", "target-dev-hub", "undelete"],
-    "alias": ["force:package:beta:version:delete", "force:package:version:delete"],
+    "alias": ["force:package:version:delete"],
     "flagChars": ["n", "p", "v"],
     "flagAliases": ["apiversion", "noprompt", "target-hub-org", "targetdevhubusername"]
   },
@@ -291,7 +291,7 @@
     "command": "package:version:displayancestry",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "dot-code", "json", "loglevel", "package", "target-dev-hub", "verbose"],
-    "alias": ["force:package:beta:version:displayancestry", "force:package:version:displayancestry"],
+    "alias": ["force:package:version:displayancestry"],
     "flagChars": ["p", "v"],
     "flagAliases": ["apiversion", "dotcode", "target-hub-org", "targetdevhubusername"]
   },
@@ -311,7 +311,7 @@
       "target-dev-hub",
       "verbose"
     ],
-    "alias": ["force:package:beta:version:list", "force:package:version:list"],
+    "alias": ["force:package:version:list"],
     "flagChars": ["c", "m", "o", "p", "r", "v"],
     "flagAliases": [
       "apiversion",
@@ -326,7 +326,7 @@
     "command": "package:version:promote",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "no-prompt", "package", "target-dev-hub"],
-    "alias": ["force:package:beta:version:promote", "force:package:version:promote"],
+    "alias": ["force:package:version:promote"],
     "flagChars": ["n", "p", "v"],
     "flagAliases": ["apiversion", "noprompt", "target-hub-org", "targetdevhubusername"]
   },
@@ -334,7 +334,7 @@
     "command": "package:version:report",
     "plugin": "@salesforce/plugin-packaging",
     "flags": ["api-version", "json", "loglevel", "package", "target-dev-hub", "verbose"],
-    "alias": ["force:package:beta:version:report", "force:package:version:report"],
+    "alias": ["force:package:version:report"],
     "flagChars": ["p", "v"],
     "flagAliases": ["apiversion", "target-hub-org", "targetdevhubusername"]
   },
@@ -361,7 +361,7 @@
       "version-description",
       "version-name"
     ],
-    "alias": ["force:package:beta:version:update", "force:package:version:update"],
+    "alias": ["force:package:version:update"],
     "flagChars": ["a", "b", "e", "k", "p", "t", "v"],
     "flagAliases": [
       "apiversion",

--- a/package.json
+++ b/package.json
@@ -7,17 +7,17 @@
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
     "@oclif/core": "^2.8.2",
-    "@salesforce/core": "^4.0.1",
+    "@salesforce/core": "^4.2.1",
     "@salesforce/kit": "^3.0.2",
     "@salesforce/packaging": "^2.1.2",
-    "@salesforce/sf-plugins-core": "^3.0.2",
+    "@salesforce/sf-plugins-core": "^3.0.4",
     "chalk": "^4.1.2",
     "tslib": "^2"
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^4.0.2",
     "@oclif/plugin-version": "^1.3.3",
-    "@salesforce/cli-plugins-testkit": "^4.0.1",
+    "@salesforce/cli-plugins-testkit": "^4.1.1",
     "@salesforce/dev-config": "^4.0.1",
     "@salesforce/dev-scripts": "^5.4.2",
     "@salesforce/plugin-auth": "^2.8.0",

--- a/src/commands/package/convert.ts
+++ b/src/commands/package/convert.ts
@@ -27,7 +27,7 @@ export class PackageConvert extends SfCommand<PackageVersionCreateRequestResult>
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:convert', 'force:package:convert'];
+  public static readonly aliases = ['force:package:convert'];
   public static readonly hidden = true;
   public static readonly flags = {
     loglevel,

--- a/src/commands/package/create.ts
+++ b/src/commands/package/create.ts
@@ -19,7 +19,7 @@ export class PackageCreateCommand extends SfCommand<PackageCreate> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:create', 'force:package:create'];
+  public static readonly aliases = ['force:package:create'];
   public static readonly requiresProject = true;
   public static readonly flags = {
     loglevel,

--- a/src/commands/package/delete.ts
+++ b/src/commands/package/delete.ts
@@ -18,7 +18,7 @@ export class PackageDeleteCommand extends SfCommand<PackageSaveResult> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:delete', 'force:package:delete'];
+  public static readonly aliases = ['force:package:delete'];
   public static readonly requiresProject = true;
   public static readonly flags = {
     loglevel,

--- a/src/commands/package/install.ts
+++ b/src/commands/package/install.ts
@@ -38,7 +38,7 @@ export class Install extends SfCommand<PackageInstallRequest> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:install', 'force:package:install'];
+  public static readonly aliases = ['force:package:install'];
   public static readonly flags = {
     loglevel,
     'target-org': requiredOrgFlagWithDeprecations,

--- a/src/commands/package/install/report.ts
+++ b/src/commands/package/install/report.ts
@@ -25,7 +25,7 @@ export class Report extends SfCommand<PackageInstallRequest> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:install:report', 'force:package:install:report'];
+  public static readonly aliases = ['force:package:install:report'];
   public static org: Org;
 
   public static readonly flags = {

--- a/src/commands/package/installed/list.ts
+++ b/src/commands/package/installed/list.ts
@@ -34,7 +34,7 @@ export class PackageInstalledListCommand extends SfCommand<PackageInstalledComma
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:installed:list', 'force:package:installed:list'];
+  public static readonly aliases = ['force:package:installed:list'];
   public static readonly requiresProject = true;
 
   public static readonly flags = {

--- a/src/commands/package/list.ts
+++ b/src/commands/package/list.ts
@@ -41,7 +41,7 @@ export class PackageListCommand extends SfCommand<PackageListCommandResult> {
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:list', 'force:package:list'];
+  public static readonly aliases = ['force:package:list'];
   public static readonly flags = {
     loglevel,
     'target-dev-hub': requiredHubFlag,

--- a/src/commands/package/uninstall.ts
+++ b/src/commands/package/uninstall.ts
@@ -26,7 +26,7 @@ export class PackageUninstallCommand extends SfCommand<UninstallResult> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:uninstall', 'force:package:uninstall'];
+  public static readonly aliases = ['force:package:uninstall'];
   public static readonly flags = {
     loglevel,
     'target-org': requiredOrgFlagWithDeprecations,

--- a/src/commands/package/uninstall/report.ts
+++ b/src/commands/package/uninstall/report.ts
@@ -22,7 +22,7 @@ export class PackageUninstallReportCommand extends SfCommand<PackagingSObjects.S
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:uninstall:report', 'force:package:uninstall:report'];
+  public static readonly aliases = ['force:package:uninstall:report'];
   public static readonly flags = {
     loglevel,
     'target-org': requiredOrgFlagWithDeprecations,

--- a/src/commands/package/update.ts
+++ b/src/commands/package/update.ts
@@ -19,7 +19,7 @@ export class PackageUpdateCommand extends SfCommand<PackageSaveResult> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:update', 'force:package:update'];
+  public static readonly aliases = ['force:package:update'];
   public static readonly requiresProject = true;
   public static readonly flags = {
     loglevel,

--- a/src/commands/package/version/create.ts
+++ b/src/commands/package/version/create.ts
@@ -31,7 +31,7 @@ export class PackageVersionCreateCommand extends SfCommand<PackageVersionCommand
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:version:create', 'force:package:version:create'];
+  public static readonly aliases = ['force:package:version:create'];
   public static readonly flags = {
     loglevel,
     'target-dev-hub': requiredHubFlag,

--- a/src/commands/package/version/create/list.ts
+++ b/src/commands/package/version/create/list.ts
@@ -24,7 +24,7 @@ export class PackageVersionCreateListCommand extends SfCommand<CreateListCommand
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:version:create:list', 'force:package:version:create:list'];
+  public static readonly aliases = ['force:package:version:create:list'];
   public static readonly flags = {
     loglevel,
     'target-dev-hub': requiredHubFlag,

--- a/src/commands/package/version/create/report.ts
+++ b/src/commands/package/version/create/report.ts
@@ -26,7 +26,7 @@ export class PackageVersionCreateReportCommand extends SfCommand<ReportCommandRe
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:version:create:report', 'force:package:version:create:report'];
+  public static readonly aliases = ['force:package:version:create:report'];
   public static readonly flags = {
     loglevel,
     'target-dev-hub': requiredHubFlag,

--- a/src/commands/package/version/delete.ts
+++ b/src/commands/package/version/delete.ts
@@ -18,7 +18,7 @@ export class PackageVersionDeleteCommand extends SfCommand<PackageSaveResult> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:version:delete', 'force:package:version:delete'];
+  public static readonly aliases = ['force:package:version:delete'];
   public static readonly requiresProject = true;
   public static readonly flags = {
     loglevel,

--- a/src/commands/package/version/displayancestry.ts
+++ b/src/commands/package/version/displayancestry.ts
@@ -20,10 +20,7 @@ export class PackageVersionDisplayAncestryCommand extends SfCommand<DisplayAnces
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = [
-    'force:package:beta:version:displayancestry',
-    'force:package:version:displayancestry',
-  ];
+  public static readonly aliases = ['force:package:version:displayancestry'];
   public static readonly requiresProject = true;
 
   public static readonly flags = {

--- a/src/commands/package/version/list.ts
+++ b/src/commands/package/version/list.ts
@@ -56,7 +56,7 @@ export class PackageVersionListCommand extends SfCommand<PackageVersionListComma
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:version:list', 'force:package:version:list'];
+  public static readonly aliases = ['force:package:version:list'];
   public static readonly flags = {
     loglevel,
     'target-dev-hub': requiredHubFlag,

--- a/src/commands/package/version/promote.ts
+++ b/src/commands/package/version/promote.ts
@@ -17,7 +17,7 @@ export class PackageVersionPromoteCommand extends SfCommand<PackageSaveResult> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:version:promote', 'force:package:version:promote'];
+  public static readonly aliases = ['force:package:version:promote'];
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
   public static readonly flags = {

--- a/src/commands/package/version/report.ts
+++ b/src/commands/package/version/report.ts
@@ -39,7 +39,7 @@ export class PackageVersionReportCommand extends SfCommand<PackageVersionReportR
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:version:report', 'force:package:version:report'];
+  public static readonly aliases = ['force:package:version:report'];
   public static readonly requiresProject = true;
   public static readonly flags = {
     loglevel,

--- a/src/commands/package/version/update.ts
+++ b/src/commands/package/version/update.ts
@@ -18,7 +18,7 @@ export class PackageVersionUpdateCommand extends SfCommand<PackageSaveResult> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package:beta:version:update', 'force:package:version:update'];
+  public static readonly aliases = ['force:package:version:update'];
   public static readonly requiresProject = true;
   public static readonly flags = {
     loglevel,

--- a/src/commands/package1/version/create.ts
+++ b/src/commands/package1/version/create.ts
@@ -27,7 +27,7 @@ export class Package1VersionCreateCommand extends SfCommand<PackageUploadRequest
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package1:beta:version:create', 'force:package1:version:create'];
+  public static readonly aliases = ['force:package1:version:create'];
 
   public static readonly flags = {
     loglevel,

--- a/src/commands/package1/version/create/get.ts
+++ b/src/commands/package1/version/create/get.ts
@@ -22,7 +22,7 @@ export class Package1VersionCreateGetCommand extends SfCommand<PackagingSObjects
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package1:beta:version:create:get', 'force:package1:version:create:get'];
+  public static readonly aliases = ['force:package1:version:create:get'];
   public static readonly flags = {
     loglevel,
     'target-org': requiredOrgFlagWithDeprecations,

--- a/src/commands/package1/version/display.ts
+++ b/src/commands/package1/version/display.ts
@@ -23,7 +23,7 @@ export class Package1VersionDisplayCommand extends SfCommand<Package1DisplayComm
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package1:beta:version:display', 'force:package1:version:display'];
+  public static readonly aliases = ['force:package1:version:display'];
 
   public static readonly flags = {
     loglevel,

--- a/src/commands/package1/version/list.ts
+++ b/src/commands/package1/version/list.ts
@@ -22,7 +22,7 @@ export class Package1VersionListCommand extends SfCommand<Package1ListCommandRes
   public static readonly summary = messages.getMessage('summary');
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
-  public static readonly aliases = ['force:package1:beta:version:list', 'force:package1:version:list'];
+  public static readonly aliases = ['force:package1:version:list'];
   public static readonly flags = {
     loglevel,
     'target-org': requiredOrgFlagWithDeprecations,

--- a/yarn.lock
+++ b/yarn.lock
@@ -961,17 +961,17 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/cli-plugins-testkit@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-4.0.1.tgz#36e384de223d424716cc45d452e172489eac7ad7"
-  integrity sha512-Refzx8WDdewNfxQ2a8RxIFUW7aiOhAgoSyUSVGqPzClofTQ14Oec/ZJ1y7AFa40QRNiUh1el47ge9F3VbdeECA==
+"@salesforce/cli-plugins-testkit@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-4.1.1.tgz#3504d7b05f63bf15a706385efb90c1c5f46c6c38"
+  integrity sha512-aGeiVYdWW6O/Q5LHCc4ZVNKihz0oiCljplbT2EmjyTyo+3Bxj1iyuo3o428+wo9BIc/Qk0jkKjqrSGS5HPDs/A==
   dependencies:
-    "@salesforce/core" "^4.0.1"
+    "@salesforce/core" "^4.1.3"
     "@salesforce/kit" "^3.0.2"
     "@salesforce/ts-types" "^2.0.2"
     "@types/shelljs" "^0.8.12"
-    archiver "^5.2.0"
     debug "^4.3.1"
+    jszip "^3.10.1"
     shelljs "^0.8.4"
     strip-ansi "6.0.1"
     ts-retry-promise "^0.7.0"
@@ -997,25 +997,25 @@
     jsonwebtoken "9.0.0"
     ts-retry-promise "^0.7.0"
 
-"@salesforce/core@^4.0.1", "@salesforce/core@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-4.1.0.tgz#909c1ef1640683f797529899dbf316d53f1aebee"
-  integrity sha512-S+5sJ3wSlpu4ATEYGDeqNMu1NaRgD5+HjtYFZiiUOdtHrUh55JD6DGcwgtrj2ojM9cnwcqlj/Ho/2yljrJdOSQ==
+"@salesforce/core@^4.0.1", "@salesforce/core@^4.1.0", "@salesforce/core@^4.1.2", "@salesforce/core@^4.1.3", "@salesforce/core@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-4.2.1.tgz#7fdbac22816d698b01b4007ba41028c230c7962e"
+  integrity sha512-1bi3era5/0lFqYNU786b1As+8JTDay1o8EUMbrhNR/GhVAH1hlJlGNgfseASrKDR9vuITykKI/5jWUa7kzFU6w==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
-    "@salesforce/kit" "^3.0.0"
+    "@salesforce/kit" "^3.0.2"
     "@salesforce/schemas" "^1.5.1"
-    "@salesforce/ts-types" "^2.0.1"
-    "@types/semver" "^7.3.13"
+    "@salesforce/ts-types" "^2.0.2"
+    "@types/semver" "^7.5.0"
     ajv "^8.12.0"
-    archiver "^5.3.0"
     change-case "^4.1.2"
     debug "^3.2.7"
     faye "^1.4.0"
     form-data "^4.0.0"
     js2xmlparser "^4.0.1"
-    jsforce "^2.0.0-beta.23"
+    jsforce "^2.0.0-beta.24"
     jsonwebtoken "9.0.0"
+    jszip "3.10.1"
     proper-lockfile "^4.1.2"
     ts-retry-promise "^0.7.0"
 
@@ -1072,7 +1072,7 @@
     shx "^0.3.3"
     tslib "^2.5.0"
 
-"@salesforce/kit@^3.0.0", "@salesforce/kit@^3.0.2":
+"@salesforce/kit@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.0.2.tgz#6474c3e9905290bbcfb3455388b140eee3ff84db"
   integrity sha512-/TbqjmxThz3+ZeLrYZFEcvn7kbK7DW0aHzotazyKsoGbqsHiiXIMNS1Cc5rfJRKQV7bKp84vMF/WCyBZJFHZKA==
@@ -1142,15 +1142,15 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.5.1.tgz#2d1bfdcf593caaa04cd4b3e6fe621097ff7f28fe"
   integrity sha512-MRqU+tn8w5IFvZ0Lm9YKLgxYxr2MQMI+fXXsTrwfUnijsps+ybF9IOTu6MOMxxl2vCUkO8XDjA435wXlWSLI6g==
 
-"@salesforce/sf-plugins-core@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-3.0.2.tgz#c184ace06c687ecc2efb320d9e41f5894c4223da"
-  integrity sha512-NI5qg1cF54Sp1anXR5ANTRkP4u8Maff7+NS44dE/1fPdhDLnTuZV4osuLoDqVVScHJOKY/+a+LjelycfjdOydg==
+"@salesforce/sf-plugins-core@^3.0.2", "@salesforce/sf-plugins-core@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-3.0.4.tgz#e62633de4f15e869b0200dfce2c633f8640d142c"
+  integrity sha512-Ap1maS6fYwD8Ipa1rJLD6EuUMMnErc7IRpEzFNJj9XH0MF4+AmkE8TpL3rcXXyVPADkrTWZXR9XhlUwIe+xU/w==
   dependencies:
     "@oclif/core" "^2.8.2"
-    "@salesforce/core" "^4.0.1"
+    "@salesforce/core" "^4.1.2"
     "@salesforce/kit" "^3.0.2"
-    "@salesforce/ts-types" "^2.0.1"
+    "@salesforce/ts-types" "^2.0.2"
     chalk "^4"
     inquirer "^8.2.5"
 
@@ -1514,10 +1514,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/semver@^7.3.12", "@types/semver@^7.3.13":
-  version "7.3.13"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
-  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+"@types/semver@^7.3.12", "@types/semver@^7.3.13", "@types/semver@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
+  integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
 
 "@types/shelljs@^0.8.12":
   version "0.8.12"
@@ -1856,7 +1856,7 @@ archiver-utils@^2.1.0:
     normalize-path "^3.0.0"
     readable-stream "^2.0.0"
 
-archiver@^5.2.0, archiver@^5.3.0, archiver@^5.3.1:
+archiver@^5.3.0, archiver@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/archiver/-/archiver-5.3.1.tgz#21e92811d6f09ecfce649fbefefe8c79e57cbbb6"
   integrity sha512-8KyabkmbYrH+9ibcTScQ1xCJC/CGcugdVIwB+53f5sZziXgwUh3iXlAlANMxcZyDEfTHMe6+Z5FofV8nopXP7w==
@@ -4891,10 +4891,10 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-jsforce@^2.0.0-beta.23:
-  version "2.0.0-beta.23"
-  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.23.tgz#5eeb1a2635498ee77f0726ababe089cc12113551"
-  integrity sha512-lfeLHbCJ40ela1JPu4VqgK1GtIzR0NQOMZ/Rxesv9Ty3PyxK18o01AQ4E+JqGAWDDQhwyUp2A/9V+uOqU3w7Rw==
+jsforce@^2.0.0-beta.23, jsforce@^2.0.0-beta.24:
+  version "2.0.0-beta.24"
+  resolved "https://registry.yarnpkg.com/jsforce/-/jsforce-2.0.0-beta.24.tgz#fe054eb0f6f668eff10566e086892dd2387364f7"
+  integrity sha512-rbDC9Y054Ele3qlDyFZxFY6RRyqpH7DKPYhAwBM2TIzqOl9OG35EB4lnJLaIuv/MZVA2mvTIV/TwxVv8PiB1EA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"
@@ -5005,7 +5005,7 @@ jsonwebtoken@9.0.0:
     ms "^2.1.1"
     semver "^7.3.8"
 
-jszip@^3.10.1:
+jszip@3.10.1, jszip@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
   integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==


### PR DESCRIPTION
### What does this PR do?
remove all the `beta` aliases for packaging commands.

because this is a breaking change, it'll cause the nightlies PRs for `sf` (on both main and v2) to fail.  You can either bump this in both branches when you merge (so that the failures don't happen) or merge the failed release PRs manually

### What issues does this PR fix or reference?
@W-12301372@