### PR TITLE
fix: reduce polling frequency

### DIFF
--- a/src/commands/package/install.ts
+++ b/src/commands/package/install.ts
@@ -194,6 +194,7 @@ export class Install extends SfCommand<PackageInstallRequest> {
     if (flags.wait) {
       installOptions = {
         pollingTimeout: flags.wait,
+        pollingFrequency: Duration.seconds(2),
       };
       let remainingTime = flags.wait;
       let timeThen = Date.now();


### PR DESCRIPTION
### What does this PR do?

plugin library passes around the `PackageInstallOptions`.  If you pass any options, it eventually gets to here
https://github.com/forcedotcom/packaging/blob/b7c470d07cfb0915752c37a84fbde04c534fc12d/src/package/packageInstall.ts#L199

where an undefined `frequency` will become `0`.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2319
[@W-13797305@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001WeCjbYAF/view)