### PR TITLE
feat: ship yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-packaging",
   "description": "SFDX plugin that support Salesforce Packaging Platform",
-  "version": "1.22.3-dev.0",
+  "version": "1.22.3-dev.1",
   "main": "lib/index.js",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
-    "@oclif/core": "^2.11.8",
+    "@oclif/core": "2.11.8",
     "@salesforce/core": "^5.2.0",
     "@salesforce/kit": "^3.0.9",
     "@salesforce/packaging": "^2.3.3",
-    "@salesforce/sf-plugins-core": "^3.1.14",
+    "@salesforce/sf-plugins-core": "3.1.17",
     "chalk": "^4.1.2",
     "tslib": "^2"
   },
@@ -58,8 +58,7 @@
     "/lib",
     "/messages",
     "/oclif.manifest.json",
-    "/schemas",
-    "yarn.lock"
+    "/schemas"
   ],
   "homepage": "https://github.com/salesforcecli/plugin-packaging",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-packaging",
   "description": "SFDX plugin that support Salesforce Packaging Platform",
-  "version": "1.22.2",
+  "version": "1.22.3-dev.0",
   "main": "lib/index.js",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "/messages",
     "/oclif.manifest.json",
     "/schemas",
-    "/yarn.lock"
+    "yarn.lock"
   ],
   "homepage": "https://github.com/salesforcecli/plugin-packaging",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-packaging",
   "description": "SFDX plugin that support Salesforce Packaging Platform",
-  "version": "1.22.3-dev.1",
+  "version": "1.22.3-dev.2",
   "main": "lib/index.js",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli/issues",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "/lib",
     "/messages",
     "/oclif.manifest.json",
-    "/schemas"
+    "/schemas",
+    "/yarn.lock"
   ],
   "homepage": "https://github.com/salesforcecli/plugin-packaging",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -754,7 +754,7 @@
     supports-color "^8.1.1"
     tslib "^2"
 
-"@oclif/core@^2.11.1", "@oclif/core@^2.11.4", "@oclif/core@^2.11.7", "@oclif/core@^2.11.8", "@oclif/core@^2.9.4":
+"@oclif/core@2.11.8", "@oclif/core@^2.11.1", "@oclif/core@^2.11.4", "@oclif/core@^2.11.7", "@oclif/core@^2.11.8", "@oclif/core@^2.9.4":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-2.11.8.tgz#780c4fdf53e8569cf754c2a8fefcc7ddeacf1747"
   integrity sha512-GILmztcHBzze45GvxRpUvqQI5nM26kSE/Q21Y+6DtMR+C8etM/hFW26D3uqIAbGlGtg5QEZZ6pjA/Fqgz+gl3A==
@@ -983,6 +983,29 @@
     proper-lockfile "^4.1.2"
     ts-retry-promise "^0.7.0"
 
+"@salesforce/core@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-5.2.1.tgz#299bddae7d0705c773b194be8994e5730735e2b4"
+  integrity sha512-QMx11A0KA/Vl+Ckmz83cw+fiUCMOmsUD8CA3987wAkfJOgxtqyhT4R1R8tj7ad8flQydKUyL3o4UE/2u82tXOw==
+  dependencies:
+    "@salesforce/kit" "^3.0.9"
+    "@salesforce/schemas" "^1.6.0"
+    "@salesforce/ts-types" "^2.0.5"
+    "@types/semver" "^7.5.0"
+    ajv "^8.12.0"
+    change-case "^4.1.2"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsforce "^2.0.0-beta.27"
+    jsonwebtoken "9.0.1"
+    jszip "3.10.1"
+    pino "^8.14.2"
+    pino-abstract-transport "^1.0.0"
+    pino-pretty "^10.2.0"
+    proper-lockfile "^4.1.2"
+    ts-retry-promise "^0.7.0"
+
 "@salesforce/dev-config@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@salesforce/dev-config/-/dev-config-4.0.1.tgz#662ffaa4409713553aaf68eed93e7d2429c3ff0e"
@@ -1093,6 +1116,18 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.0.tgz#14505ebad2fb2d4f7b14837545d662766d293561"
   integrity sha512-SwhDTLucj/GRbPpxlEoDZeqlX22o+G6fiebTXTu1cZKmd1oE0W2L7SlTTgJnWck8bhTeBIgQi9cpD8c2t5ISKA==
 
+"@salesforce/sf-plugins-core@3.1.17":
+  version "3.1.17"
+  resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-3.1.17.tgz#465d406f677cb7eb10e8a28d1c9e119cd0fb750d"
+  integrity sha512-WZnVOLQDlwDSw5t5vC1vGcgEghUBjH7z8/uaUNgvYlcF8Ankl+Y27hN9dadTbRLrIh2ARyDVhoiFsWz1dgtENQ==
+  dependencies:
+    "@oclif/core" "^2.11.7"
+    "@salesforce/core" "^5.2.1"
+    "@salesforce/kit" "^3.0.9"
+    "@salesforce/ts-types" "^2.0.7"
+    chalk "^4"
+    inquirer "^8.2.5"
+
 "@salesforce/sf-plugins-core@^3.1.14":
   version "3.1.14"
   resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-3.1.14.tgz#b2ca3bacfdfe338ccceafc2b92b968aa0780be4b"
@@ -1139,6 +1174,13 @@
   integrity sha512-hGSU3pwZKItAw567cD2hf+nwe4yPVANonb1E28bLVaRjYAI6FmdxjjTxA+wZRrTpTCpjd5TY67Lq2X1X1lY8bA==
   dependencies:
     tslib "^2.6.1"
+
+"@salesforce/ts-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-2.0.7.tgz#02a6999d0b0e7bcd6c6d8ce621c79fa61af24701"
+  integrity sha512-8csXgstPuy6QXL3JavkIi/f8DOWHBNCvWeszrFu5sbVlcKO3YqOOCE+rDFGPkrZsYv5OywV6H8kEi877bWOz6Q==
+  dependencies:
+    tslib "^2.6.2"
 
 "@sigstore/bundle@^1.0.0":
   version "1.0.0"
@@ -7581,6 +7623,11 @@ tslib@^2, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.5.0, 
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
   integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
+
+tslib@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
### What does this PR do?

Publishes yarn.lock to npm. Theoretically this will allow plugin-plugins to use the deps specified in the yarn.lock during install. See https://github.com/oclif/plugin-plugins/blob/main/src/plugins.ts#L123

Will try this as a dev release first before merging

### What issues does this PR fix or reference?
[skip-validate-pr]