### PR TITLE
feat: make visible the enable-app-analytics flag to the sf package update command

### DIFF
--- a/src/commands/package/update.ts
+++ b/src/commands/package/update.ts
@@ -49,7 +49,6 @@ export class PackageUpdateCommand extends SfCommand<PackageSaveResult> {
     'enable-app-analytics': Flags.boolean({
       summary: messages.getMessage('flags.enable-app-analytics.summary'),
       allowNo: true,
-      hidden: true, // Only hidden while we wait for api-version 59.0 to ship with 246 (after September 2023)
     }),
   };
 


### PR DESCRIPTION
### What does this PR do?
As 246 roles out we are now prepared to make visible the --enable-app-analytics flag on the sf package update command

### What issues does this PR fix or reference?
@W-13153221@