### PR TITLE
feat: hide 'package version retrieve' command

### DIFF
--- a/src/commands/package/version/retrieve.ts
+++ b/src/commands/package/version/retrieve.ts
@@ -29,6 +29,7 @@ export type FileDownloadEntry = {
 export type PackageVersionRetrieveCommandResult = FileDownloadEntry[];
 
 export class PackageVersionRetrieveCommand extends SfCommand<PackageVersionRetrieveCommandResult> {
+  public static readonly hidden = true;
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');


### PR DESCRIPTION
### What does this PR do?
@W-14169543 - Re-hide the `sf package version retrieve` command. This command will only work if the org has a newly introduced org perm. We will update the relevant error message in the `packaging` repo as well. 

### What issues does this PR fix or reference?
@W-14169543@