### PR TITLE
test: reset plugins before running json command

### DIFF
--- a/test/commands/package/packageList.nut.ts
+++ b/test/commands/package/packageList.nut.ts
@@ -29,6 +29,7 @@ describe('package list', () => {
     await session?.clean();
   });
   it('should list packages in dev hub - json results', async () => {
+    execCmd('plugins reset', { ensureExitCode: 0, cli: 'sf' });
     const packages = await Package.list(hubOrg.getConnection());
     const command = `package:list -v ${session.hubOrg.username} --json`;
     const output = execCmd<{ [key: string]: unknown }>(command, { ensureExitCode: 0 }).jsonOutput;


### PR DESCRIPTION
### What does this PR do?
make sure plugin isn't installed before running a --json to test JIT

### What issues does this PR fix or reference?
[skip-validate-pr] test-only