### PR TITLE
feat: use new inquirer via sf-plugins-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
     "@oclif/core": "^3.14.1",
-    "@salesforce/core": "^6.4.2",
+    "@salesforce/core": "^6.4.4",
     "@salesforce/kit": "^3.0.15",
-    "@salesforce/packaging": "^3.0.15",
-    "@salesforce/sf-plugins-core": "5.0.14-dev.1",
+    "@salesforce/packaging": "^3.1.0",
+    "@salesforce/sf-plugins-core": "^7.0.0",
     "chalk": "^5.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@salesforce/core": "^6.4.2",
     "@salesforce/kit": "^3.0.15",
     "@salesforce/packaging": "^3.0.15",
-    "@salesforce/sf-plugins-core": "^5.0.9",
+    "@salesforce/sf-plugins-core": "5.0.14-dev.1",
     "chalk": "^5.3.0"
   },
   "devDependencies": {

--- a/src/commands/package/create.ts
+++ b/src/commands/package/create.ts
@@ -85,7 +85,7 @@ export class PackageCreateCommand extends SfCommand<PackageCreate> {
     };
     const result: PackageCreate = await Package.create(
       flags['target-dev-hub'].getConnection(flags['api-version']),
-      this.project,
+      this.project!,
       options
     );
     this.display(result);

--- a/src/commands/package/delete.ts
+++ b/src/commands/package/delete.ts
@@ -44,15 +44,15 @@ export class PackageDeleteCommand extends SfCommand<PackageSaveResult> {
 
   public async run(): Promise<PackageSaveResult> {
     const { flags } = await this.parse(PackageDeleteCommand);
-    const promptMsg = flags.undelete ? 'prompt-undelete' : 'prompt-delete';
-    const accepted = flags['no-prompt'] || flags.json ? true : await this.confirm(messages.getMessage(promptMsg));
+    const message = messages.getMessage(flags.undelete ? 'prompt-undelete' : 'prompt-delete');
+    const accepted = flags['no-prompt'] || flags.json ? true : await this.confirm({ message });
     if (!accepted) {
       throw messages.createError('prompt-delete-deny');
     }
 
     const pkg = new Package({
       connection: flags['target-dev-hub'].getConnection(flags['api-version']),
-      project: this.project,
+      project: this.project!,
       packageAliasOrId: flags.package,
     });
     const result = flags.undelete ? await pkg.undelete() : await pkg.delete();

--- a/src/commands/package/install.ts
+++ b/src/commands/package/install.ts
@@ -253,7 +253,7 @@ export class Install extends SfCommand<PackageInstallRequest> {
   private async confirmUpgradeType(noPrompt: boolean): Promise<void> {
     if ((await this.subscriberPackageVersion.getPackageType()) === 'Unlocked' && !noPrompt) {
       const promptMsg = messages.getMessage('prompt-upgrade-type');
-      if (!(await this.confirm(promptMsg))) {
+      if (!(await this.confirm({ message: promptMsg }))) {
         throw messages.createError('promptUpgradeTypeDeny');
       }
     }
@@ -265,7 +265,7 @@ export class Install extends SfCommand<PackageInstallRequest> {
       let enableRss = true;
       if (!noPrompt) {
         const promptMsg = messages.getMessage('promptEnableRss', [extSites.join('\n')]);
-        enableRss = await this.confirm(promptMsg);
+        enableRss = await this.confirm({ message: promptMsg });
       }
       if (enableRss) {
         request.EnableRss = enableRss;

--- a/src/commands/package/list.ts
+++ b/src/commands/package/list.ts
@@ -88,7 +88,7 @@ export class PackageListCommand extends SfCommand<PackageListCommandResult> {
               NamespacePrefix,
               ContainerOptions,
               ConvertedFromPackageId,
-              Alias: this.project.getAliasesFromPackageId(Id).join(),
+              Alias: this.project!.getAliasesFromPackageId(Id).join(),
               IsOrgDependent: ContainerOptions === 'Managed' ? 'N/A' : IsOrgDependent ? 'Yes' : 'No',
               PackageErrorUsername,
               AppAnalyticsEnabled,

--- a/src/commands/package/update.ts
+++ b/src/commands/package/update.ts
@@ -57,7 +57,7 @@ export class PackageUpdateCommand extends SfCommand<PackageSaveResult> {
     const pkg = new Package({
       packageAliasOrId: flags.package,
       connection: flags['target-dev-hub'].getConnection(flags['api-version']),
-      project: this.project,
+      project: this.project!,
     });
 
     const result = await pkg.update({

--- a/src/commands/package/version/create.ts
+++ b/src/commands/package/version/create.ts
@@ -225,7 +225,7 @@ export class PackageVersionCreateCommand extends SfCommand<PackageVersionCommand
     const result = await PackageVersion.create(
       {
         connection: flags['target-dev-hub'].getConnection(flags['api-version']),
-        project: this.project,
+        project: this.project!,
         ...Object.fromEntries(Object.entries(flags).map(([key, value]) => [key.replace(/-/g, ''), value])),
         packageId: flags.package,
         path: flags.path,

--- a/src/commands/package/version/delete.ts
+++ b/src/commands/package/version/delete.ts
@@ -45,7 +45,7 @@ export class PackageVersionDeleteCommand extends SfCommand<PackageSaveResult> {
     const { flags } = await this.parse(PackageVersionDeleteCommand);
     const packageVersion = new PackageVersion({
       connection: flags['target-dev-hub'].getConnection(flags['api-version']),
-      project: this.project,
+      project: this.project!,
       idOrAlias: flags.package,
     });
     await this.confirmDelete(flags['no-prompt'], flags.undelete);
@@ -59,7 +59,7 @@ export class PackageVersionDeleteCommand extends SfCommand<PackageSaveResult> {
       return true;
     }
     const message = undelete ? messages.getMessage('prompt-undelete') : messages.getMessage('prompt-delete');
-    const accepted = await this.confirm(message);
+    const accepted = await this.confirm({ message });
     if (!accepted) {
       throw new Error(messages.getMessage('prompt-delete-deny'));
     }

--- a/src/commands/package/version/displayancestry.ts
+++ b/src/commands/package/version/displayancestry.ts
@@ -48,7 +48,7 @@ export class PackageVersionDisplayAncestryCommand extends SfCommand<DisplayAnces
     const { flags } = await this.parse(PackageVersionDisplayAncestryCommand);
     const packageAncestry = await Package.getAncestry(
       flags.package,
-      this.project,
+      this.project!,
       flags['target-dev-hub'].getConnection(flags['api-version'])
     );
     const jsonProducer = packageAncestry.getJsonProducer();

--- a/src/commands/package/version/promote.ts
+++ b/src/commands/package/version/promote.ts
@@ -41,7 +41,7 @@ export class PackageVersionPromoteCommand extends SfCommand<PackageSaveResult> {
     const { flags } = await this.parse(PackageVersionPromoteCommand);
     const packageVersion = new PackageVersion({
       connection: flags['target-dev-hub'].getConnection(flags['api-version']),
-      project: this.project,
+      project: this.project!,
       idOrAlias: flags.package,
     });
     const packageVersionData = await packageVersion.getData();
@@ -53,7 +53,7 @@ export class PackageVersionPromoteCommand extends SfCommand<PackageSaveResult> {
       }
 
       // Prompt for confirmation
-      if (!(await this.confirm(messages.getMessage('packageVersionPromoteConfirm', [flags.package])))) {
+      if (!(await this.confirm({ message: messages.getMessage('packageVersionPromoteConfirm', [flags.package]) }))) {
         throw messages.createError('promote-deny');
       }
     }

--- a/src/commands/package/version/report.ts
+++ b/src/commands/package/version/report.ts
@@ -59,7 +59,7 @@ export class PackageVersionReportCommand extends SfCommand<PackageVersionReportR
     const { flags } = await this.parse(PackageVersionReportCommand);
     const packageVersion = new PackageVersion({
       connection: flags['target-dev-hub'].getConnection(flags['api-version']),
-      project: this.project,
+      project: this.project!,
       idOrAlias: flags.package,
     });
     const results = await packageVersion.report(flags.verbose);

--- a/src/commands/package/version/retrieve.ts
+++ b/src/commands/package/version/retrieve.ts
@@ -59,7 +59,7 @@ export class PackageVersionRetrieveCommand extends SfCommand<PackageVersionRetri
     };
 
     const result: PackageVersionMetadataDownloadResult = await Package.downloadPackageVersionMetadata(
-      this.project,
+      this.project!,
       options,
       connection
     );

--- a/src/commands/package/version/update.ts
+++ b/src/commands/package/version/update.ts
@@ -61,7 +61,7 @@ export class PackageVersionUpdateCommand extends SfCommand<PackageSaveResult> {
     const { flags } = await this.parse(PackageVersionUpdateCommand);
     const pv = new PackageVersion({
       connection: flags['target-dev-hub'].getConnection(flags['api-version']),
-      project: this.project,
+      project: this.project!,
       idOrAlias: flags.package,
     });
     const result = await pv.update({

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,6 +442,59 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz#e5211452df060fa8522b55c7b3c0c4d1981cb044"
   integrity sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==
 
+"@inquirer/confirm@^2.0.15":
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-2.0.15.tgz#b5512ed190efd8c5b96e0969115756b48546ab36"
+  integrity sha512-hj8Q/z7sQXsF0DSpLQZVDhWYGN6KLM/gNjjqGkpKwBzljbQofGjn0ueHADy4HUY+OqDHmXuwk/bY+tZyIuuB0w==
+  dependencies:
+    "@inquirer/core" "^5.1.1"
+    "@inquirer/type" "^1.1.5"
+    chalk "^4.1.2"
+
+"@inquirer/core@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-5.1.1.tgz#849d4846aea68371c133df6ec9059f5e5bd30d30"
+  integrity sha512-IuJyZQUg75+L5AmopgnzxYrgcU6PJKL0hoIs332G1Gv55CnmZrhG6BzNOeZ5sOsTi1YCGOopw4rYICv74ejMFg==
+  dependencies:
+    "@inquirer/type" "^1.1.5"
+    "@types/mute-stream" "^0.0.4"
+    "@types/node" "^20.9.0"
+    "@types/wrap-ansi" "^3.0.0"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    cli-spinners "^2.9.1"
+    cli-width "^4.1.0"
+    figures "^3.2.0"
+    mute-stream "^1.0.0"
+    run-async "^3.0.0"
+    signal-exit "^4.1.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^6.2.0"
+
+"@inquirer/input@^1.2.14":
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-1.2.14.tgz#8951867618bb5cd16dd096e02404eec225a92207"
+  integrity sha512-tISLGpUKXixIQue7jypNEShrdzJoLvEvZOJ4QRsw5XTfrIYfoWFqAjMQLerGs9CzR86yAI89JR6snHmKwnNddw==
+  dependencies:
+    "@inquirer/core" "^5.1.1"
+    "@inquirer/type" "^1.1.5"
+    chalk "^4.1.2"
+
+"@inquirer/password@^1.1.14":
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-1.1.14.tgz#c1fc139efe84a38986870a1bcf80718050f82bbf"
+  integrity sha512-vL2BFxfMo8EvuGuZYlryiyAB3XsgtbxOcFs4H9WI9szAS/VZCAwdVqs8rqEeaAf/GV/eZOghIOYxvD91IsRWSg==
+  dependencies:
+    "@inquirer/input" "^1.2.14"
+    "@inquirer/type" "^1.1.5"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+
+"@inquirer/type@^1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-1.1.5.tgz#b8c171f755859c8159b10e41e1e3a88f0ca99d7f"
+  integrity sha512-wmwHvHozpPo4IZkkNtbYenem/0wnfI6hvOcGKmPEa0DwuaH5XUQzFqy6OpEpjEegZMhYIk8HDYITI16BPLtrRA==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -789,7 +842,7 @@
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/core@^3", "@oclif/core@^3.0.4", "@oclif/core@^3.12.0", "@oclif/core@^3.14.1", "@oclif/core@^3.15.0", "@oclif/core@^3.15.1":
+"@oclif/core@^3", "@oclif/core@^3.0.4", "@oclif/core@^3.12.0", "@oclif/core@^3.14.1", "@oclif/core@^3.15.0", "@oclif/core@^3.15.1", "@oclif/core@^3.16.0":
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.16.0.tgz#682657cb5e4a3262a47e26e0c8a7bf0343acaf76"
   integrity sha512-/PIz+udzb59XE8O/bQvqlCtXy6RByEHH0KsrAJNa/ZrqtdsLmeDNJcHdgygFHx+nz+PYMoUzsyzJMau++EDNoQ==
@@ -1097,7 +1150,20 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.1.tgz#7d1c071e1e509ca9d2d8a6e48ac7447dd67a534d"
   integrity sha512-eVy947ZMxCJReKJdgfddUIsBIbPTa/i8RwQGwxq4/ss38H5sLOAeSTaun9V7HpJ1hkpDznWKfgzYvjsst9K6ig==
 
-"@salesforce/sf-plugins-core@^5.0.12", "@salesforce/sf-plugins-core@^5.0.9":
+"@salesforce/sf-plugins-core@5.0.14-dev.1":
+  version "5.0.14-dev.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-5.0.14-dev.1.tgz#6d197202f848bd8762365d2d2c7bac55187bf42e"
+  integrity sha512-mRJ+udM6oGE8EIta8umcFkZEoHKvYvfE+G87jjkoVoOCFqcSd6eImxvJe4hly9M8c4R5f8te/UnmIseMMlAT7Q==
+  dependencies:
+    "@inquirer/confirm" "^2.0.15"
+    "@inquirer/password" "^1.1.14"
+    "@oclif/core" "^3.16.0"
+    "@salesforce/core" "^6.4.2"
+    "@salesforce/kit" "^3.0.15"
+    "@salesforce/ts-types" "^2.0.9"
+    chalk "^5.3.0"
+
+"@salesforce/sf-plugins-core@^5.0.12":
   version "5.0.13"
   resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-5.0.13.tgz#f2941527d66ded5750a6646e146af047ab72acc9"
   integrity sha512-b5R8krKeOIkW0hPxvfpm8T5tCSyWW7MDERnJwm/FXq4ueUJsC1/TCWSscyVKPSZ0VRcEFbzOWKJvpV/omB1D9w==
@@ -1341,10 +1407,19 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.6.tgz#818551d39113081048bdddbef96701b4e8bb9d1b"
   integrity sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==
 
-"@types/node@*":
-  version "20.4.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.6.tgz#b66b66c9bb5d49b199f03399e341c9d6036e9e88"
-  integrity sha512-q0RkvNgMweWWIvSMDiXhflGUKMdIxBo2M2tYM/0kEGDueQByFzK4KZAgu5YHGFNxziTlppNpTIBcqHQAxlfHdA==
+"@types/mute-stream@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@types/mute-stream/-/mute-stream-0.0.4.tgz#77208e56a08767af6c5e1237be8888e2f255c478"
+  integrity sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==
+  dependencies:
+    "@types/node" "*"
+
+"@types/node@*", "@types/node@^20.9.0":
+  version "20.10.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.10.6.tgz#a3ec84c22965802bf763da55b2394424f22bfbb5"
+  integrity sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/node@^12.19.9":
   version "12.20.55"
@@ -1419,6 +1494,11 @@
   dependencies:
     "@types/expect" "^1.20.4"
     "@types/node" "*"
+
+"@types/wrap-ansi@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz#18b97a972f94f60a679fd5c796d96421b9abb9fd"
+  integrity sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==
 
 "@typescript-eslint/eslint-plugin@^6.10.0":
   version "6.11.0"
@@ -2343,10 +2423,10 @@ cli-progress@^3.12.0:
   dependencies:
     string-width "^4.2.3"
 
-cli-spinners@^2.5.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.0.tgz#5881d0ad96381e117bbe07ad91f2008fe6ffd8db"
-  integrity sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==
+cli-spinners@^2.5.0, cli-spinners@^2.9.1:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.2.tgz#1773a8f4b9c4d6ac31563df53b3fc1d79462fe41"
+  integrity sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==
 
 cli-table@^0.3.1:
   version "0.3.11"
@@ -2359,6 +2439,11 @@ cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+cli-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.1.0.tgz#42daac41d3c254ef38ad8ac037672130173691c5"
+  integrity sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==
 
 cliui@^6.0.0:
   version "6.0.0"
@@ -3446,7 +3531,7 @@ faye@^1.4.0:
     tough-cookie "*"
     tunnel-agent "*"
 
-figures@^3.0.0:
+figures@^3.0.0, figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -5602,6 +5687,11 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mute-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
+  integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
+
 nanoid@3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
@@ -6900,6 +6990,11 @@ run-async@^2.0.0, run-async@^2.4.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
+run-async@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-3.0.0.tgz#42a432f6d76c689522058984384df28be379daad"
+  integrity sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -7112,7 +7207,7 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-signal-exit@^4.0.1:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,10 +1038,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.7.1"
 
-"@salesforce/core@^6.4.0", "@salesforce/core@^6.4.1", "@salesforce/core@^6.4.2":
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.4.2.tgz#e6e5e2d5e6ad17f1cbe0feb5a0e55e8b74c91e3c"
-  integrity sha512-ZtLwgI18f1th6SY0fKmuiyVGGwTXPy4nI+KfXzkww/vqdPxDhAfoHwqvFeo4tjFE2rldK7IPiIIYdtpsaI8d5g==
+"@salesforce/core@^6.4.0", "@salesforce/core@^6.4.1", "@salesforce/core@^6.4.2", "@salesforce/core@^6.4.4":
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.4.4.tgz#e96d2ef9cd05c3894578374d1054af80bfdca119"
+  integrity sha512-VegX3ChnJUOOztSP05QPiXCTOSioShB22NyhYjL7vVhf6yqSOH0VT2oQ3ywrMYbYCbjLSdsmFdTVLiQIFpK57g==
   dependencies:
     "@salesforce/kit" "^3.0.15"
     "@salesforce/schemas" "^1.6.1"
@@ -1057,7 +1057,7 @@
     jszip "3.10.1"
     pino "^8.16.2"
     pino-abstract-transport "^1.1.0"
-    pino-pretty "^10.3.0"
+    pino-pretty "^10.3.1"
     proper-lockfile "^4.1.2"
     semver "^7.5.4"
     ts-retry-promise "^0.7.1"
@@ -1107,10 +1107,10 @@
     "@salesforce/ts-types" "^2.0.9"
     tslib "^2.6.2"
 
-"@salesforce/packaging@^3.0.15":
-  version "3.0.15"
-  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-3.0.15.tgz#14c40552d45a80d238706a5e2017cb98526f1e24"
-  integrity sha512-VwejqIJDHEjk0gXnY9jN4xThE09nJMi1D5skcbgJ8POFqEG65F4d3oCQDJliXJ0zcZKXcrCSBkZcWSxPn+lZKg==
+"@salesforce/packaging@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-3.1.0.tgz#2c07d90350226d92d105c13cfa77a7299b9c2cab"
+  integrity sha512-4FOYsZWn4Qb5WshiA3nXXS6WWINCAn9jPT23uSPOnz/uV6nEufeCKvEVHyRk9zrJJIckCua1JIgK2DkWsfSNMA==
   dependencies:
     "@oclif/core" "^3"
     "@salesforce/core" "^6.4.0"
@@ -1150,19 +1150,6 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.1.tgz#7d1c071e1e509ca9d2d8a6e48ac7447dd67a534d"
   integrity sha512-eVy947ZMxCJReKJdgfddUIsBIbPTa/i8RwQGwxq4/ss38H5sLOAeSTaun9V7HpJ1hkpDznWKfgzYvjsst9K6ig==
 
-"@salesforce/sf-plugins-core@5.0.14-dev.1":
-  version "5.0.14-dev.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-5.0.14-dev.1.tgz#6d197202f848bd8762365d2d2c7bac55187bf42e"
-  integrity sha512-mRJ+udM6oGE8EIta8umcFkZEoHKvYvfE+G87jjkoVoOCFqcSd6eImxvJe4hly9M8c4R5f8te/UnmIseMMlAT7Q==
-  dependencies:
-    "@inquirer/confirm" "^2.0.15"
-    "@inquirer/password" "^1.1.14"
-    "@oclif/core" "^3.16.0"
-    "@salesforce/core" "^6.4.2"
-    "@salesforce/kit" "^3.0.15"
-    "@salesforce/ts-types" "^2.0.9"
-    chalk "^5.3.0"
-
 "@salesforce/sf-plugins-core@^5.0.12":
   version "5.0.13"
   resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-5.0.13.tgz#f2941527d66ded5750a6646e146af047ab72acc9"
@@ -1175,6 +1162,19 @@
     "@types/inquirer" "^8.2.3"
     chalk "^4"
     inquirer "^8.2.5"
+
+"@salesforce/sf-plugins-core@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/sf-plugins-core/-/sf-plugins-core-7.0.0.tgz#56cb4eaafcd04a183938d86c5e93323e037b15ab"
+  integrity sha512-vl53Ee0/eg9wgvtWro6kX82/943s28Hph/o3lTQk6URorfqMC+zH0RGKJj1X0VKeLhDSOCRYXqIu54jE8AZ/3g==
+  dependencies:
+    "@inquirer/confirm" "^2.0.15"
+    "@inquirer/password" "^1.1.14"
+    "@oclif/core" "^3.16.0"
+    "@salesforce/core" "^6.4.2"
+    "@salesforce/kit" "^3.0.15"
+    "@salesforce/ts-types" "^2.0.9"
+    chalk "^5.3.0"
 
 "@salesforce/source-deploy-retrieve@^10.2.5":
   version "10.2.5"
@@ -6488,7 +6488,7 @@ pino-abstract-transport@^1.0.0, pino-abstract-transport@^1.1.0, pino-abstract-tr
     readable-stream "^4.0.0"
     split2 "^4.0.0"
 
-pino-pretty@^10.3.0:
+pino-pretty@^10.3.1:
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-10.3.1.tgz#e3285a5265211ac6c7cd5988f9e65bf3371a0ca9"
   integrity sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==


### PR DESCRIPTION
> requires https://github.com/salesforcecli/sf-plugins-core/pull/479

### What does this PR do?
use the next version of sf-plugins-core for prompts 

had do do a lot of `this.project!` now that sfCommand properly types it as optional

### What issues does this PR fix or reference?
@W-13801582@