### PR TITLE
fix: set string replace env var before convert

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
     "@oclif/core": "^3.14.1",
-    "@salesforce/core": "^6.4.4",
+    "@salesforce/core": "^6.5.1",
     "@salesforce/kit": "^3.0.15",
-    "@salesforce/packaging": "^3.2.6",
+    "@salesforce/packaging": "^3.2.8",
     "@salesforce/sf-plugins-core": "^7.0.0",
     "chalk": "^5.3.0"
   },

--- a/src/commands/package/version/create.ts
+++ b/src/commands/package/version/create.ts
@@ -7,7 +7,7 @@
 
 import os from 'node:os';
 import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand } from '@salesforce/sf-plugins-core';
-import { camelCaseToTitleCase, Duration } from '@salesforce/kit';
+import { camelCaseToTitleCase, Duration, env } from '@salesforce/kit';
 import { Lifecycle, Messages } from '@salesforce/core';
 import {
   INSTALL_URL_BASE,
@@ -221,6 +221,10 @@ export class PackageVersionCreateCommand extends SfCommand<PackageVersionCommand
     } else {
       this.spinner.start(startMsg);
     }
+
+    // Set the SF_APPLY_REPLACEMENTS_ON_CONVERT env var so that
+    // string replacements happen automatically.
+    env.setBoolean('SF_APPLY_REPLACEMENTS_ON_CONVERT', true);
 
     const result = await PackageVersion.create(
       {

--- a/test/commands/package/packageVersionCreate.test.ts
+++ b/test/commands/package/packageVersionCreate.test.ts
@@ -11,6 +11,7 @@ import { assert, expect } from 'chai';
 import { PackageVersion, PackageVersionCreateRequestResult, PackagingSObjects } from '@salesforce/packaging';
 import sinon from 'sinon';
 import { SfCommand } from '@salesforce/sf-plugins-core';
+import { env } from '@salesforce/kit';
 import { PackageVersionCreateCommand } from '../../../src/commands/package/version/create.js';
 import Package2VersionStatus = PackagingSObjects.Package2VersionStatus;
 
@@ -76,9 +77,12 @@ describe('package:version:create - tests', () => {
   describe('package:version:create', () => {
     it('should create a new package version', async () => {
       createStub.resolves(pkgVersionCreateSuccessResult);
+      const envSpy = $$.SANDBOX.spy(env, 'setBoolean').withArgs('SF_APPLY_REPLACEMENTS_ON_CONVERT', true);
+
       const cmd = new PackageVersionCreateCommand(['-p', '05i3i000000Gmj6XXX', '-v', 'test@hub.org', '-x'], config);
       stubSpinner(cmd);
       const res = await cmd.run();
+      expect(envSpy.calledOnce).to.equal(true);
       expect(res).to.deep.equal({
         Branch: undefined,
         CreatedBy: '0053i000001ZIyGAAW',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1619,10 +1619,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.0"
 
-"@salesforce/core@^6.4.0", "@salesforce/core@^6.4.1", "@salesforce/core@^6.4.2", "@salesforce/core@^6.4.4", "@salesforce/core@^6.4.7":
-  version "6.4.7"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.4.7.tgz#f15538380aa5c75de697d3c95a2ddbdabae69dbb"
-  integrity sha512-gebjw2xC8Z0gqS3lYRQWz7J+PuGZtybotrnnaJbnzzxdfpBFIp6PjW4nt/235BQW9UWFTLaQh+AwkFgmMTTSkA==
+"@salesforce/core@^6.4.0", "@salesforce/core@^6.4.1", "@salesforce/core@^6.4.2", "@salesforce/core@^6.4.7", "@salesforce/core@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.5.1.tgz#3d387a6f0b93485274ec046dde5cf1364a3a00b0"
+  integrity sha512-u/R82JGdbJCMY0EN3UY5hQUxn0gPN+ParNQIm9YPB9lDpBQv82nKeZJuH6j2LsaaF6ygY3bm79kftPxpdKbggQ==
   dependencies:
     "@salesforce/kit" "^3.0.15"
     "@salesforce/schemas" "^1.6.1"
@@ -1688,16 +1688,16 @@
     "@salesforce/ts-types" "^2.0.9"
     tslib "^2.6.2"
 
-"@salesforce/packaging@^3.2.6":
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-3.2.6.tgz#bcd9e8ee513846ff2d5b6856c7a45acfb8dcd81b"
-  integrity sha512-thj7SO1/pNAkMfgW1UGuxpPaQavaPHnIxFTvzXNlBkjoMCi+E+wPznytK80Jf4LbFNqIRek3JnoYbGL06pzzOA==
+"@salesforce/packaging@^3.2.8":
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-3.2.8.tgz#b2548568c774d67928a1d48849d014598a9103b7"
+  integrity sha512-gIhEBq7E+5pcNK+Jp8NFsfQV0W9XvlmAJlXlPafyglWxnhOhMIcR6xzOxR9CwbSFVlHAX7lSBFpbbOPsLVJaPg==
   dependencies:
     "@oclif/core" "^3"
-    "@salesforce/core" "^6.4.7"
+    "@salesforce/core" "^6.5.1"
     "@salesforce/kit" "^3.0.15"
     "@salesforce/schemas" "^1.6.1"
-    "@salesforce/source-deploy-retrieve" "^10.2.11"
+    "@salesforce/source-deploy-retrieve" "^10.2.13"
     "@salesforce/ts-types" "^2.0.9"
     fast-xml-parser "^4.3.3"
     globby "^11"
@@ -1757,12 +1757,12 @@
     "@salesforce/ts-types" "^2.0.9"
     chalk "^5.3.0"
 
-"@salesforce/source-deploy-retrieve@^10.2.11":
-  version "10.2.11"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-10.2.11.tgz#b3eaa75a1342d9dfbc8d84ff05d1a8ebf48b5241"
-  integrity sha512-XUoSn4I4Ki9m6rX/DaGpfM4PBu2TP/WSDszhlwvfktSO4XjLCqdI2B5KrGk/BQZ5KoxDQIhDp2G7rwgoyypJxw==
+"@salesforce/source-deploy-retrieve@^10.2.13":
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-10.3.1.tgz#d5c26b20aebc0ba0a0f5cdb14017e75a4b4b8cde"
+  integrity sha512-S+nHAepnxLSf0vgo0b2CyH2matnGKsNBQ6AM/uEHrwpOBjLW/46cVXlY2umUG9fXQwG0ubeMYHm+IUmppDysUA==
   dependencies:
-    "@salesforce/core" "^6.4.7"
+    "@salesforce/core" "^6.5.1"
     "@salesforce/kit" "^3.0.15"
     "@salesforce/ts-types" "^2.0.9"
     fast-levenshtein "^3.0.0"


### PR DESCRIPTION
Sets SF_APPLY_REPLACEMENTS_ON_CONVERT=true before converting packaged metadata so that strings are replaced automatically without the need for setting this env var explicitly. String replacement happens automatically during a deploy, so this matches the expected behavior.

@W-14914086@
