### PR TITLE
Update DEVELOPING.md

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -29,7 +29,7 @@
 1.  Build and lint the code: `yarn build`
 1.  Create a branch off main for new work: `git checkout -b <branch_name>` _Suggestion: use branch_name format of initials/work-title_. For external contributors, please fork the main branch of the repo instead and PR the fork to the main branch.
 1.  Make code changes and build: `yarn build`
-1.  Run changed commands: e.g., `./bin/dev.js package:create -h`
+1.  Run changed commands: e.g., `./bin/run.js package:create -h`
 1.  Write tests and run: `yarn test` (unit) and/or `yarn test:nuts` (NUTs)
 1.  Show all changed files: `git status`
 1.  Add all files to staging: `git add .`
@@ -59,11 +59,11 @@ When you want to use a branch of the packaging library in this plugin to test ch
 
 ## Running Commands
 
-To run your modified plugin commands locally, use `./bin/dev.js` or `./bin/dev.cmd` (Windows).
+To run your modified plugin commands locally, use `./bin/run.js` or `./bin/run.cmd` (Windows). Note that you must compile any code changes (`yarn compile`) before seeing those changes with `./bin/run.js`.
 
 ```bash
-# Run using local dev file.
-./bin/dev.js package:create --help
+# Run using local script.
+./bin/run.js package:create --help
 ```
 
 There should be no differences when running via the Salesforce CLI or using the local scripts. However, it can be useful to link the plugin to do some additional testing or run your commands from anywhere on your machine.


### PR DESCRIPTION
### What does this PR do?
Updates DEVELOPING.md doc to recommend using `run.js` and `run.cmd` rather than `dev.js` and `dev.cmd`.

[skip-validate-pr]