### PR TITLE
feat: regular color table headers, no chalk dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "@salesforce/core": "^7.3.8",
     "@salesforce/kit": "^3.1.0",
     "@salesforce/packaging": "^3.5.16",
-    "@salesforce/sf-plugins-core": "^10.0.0",
-    "chalk": "^5.3.0"
+    "@salesforce/sf-plugins-core": "^10.0.0"
   },
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^5.1.8",

--- a/src/commands/package/list.ts
+++ b/src/commands/package/list.ts
@@ -8,7 +8,6 @@
 import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core/messages';
 import { Package, PackagingSObjects } from '@salesforce/packaging';
-import chalk from 'chalk';
 import { requiredHubFlag } from '../../utils/hubFlag.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
@@ -99,7 +98,7 @@ export class PackageListCommand extends SfCommand<PackageListCommandResult> {
   }
 
   private displayResults(verbose = false, apiVersion: string): void {
-    this.styledHeader(chalk.blue(`Packages [${this.results.length}]`));
+    this.styledHeader(`Packages [${this.results.length}]`);
     const columns = {
       NamespacePrefix: { header: messages.getMessage('namespace') },
       Name: { header: messages.getMessage('name') },

--- a/src/commands/package/version/create/list.ts
+++ b/src/commands/package/version/create/list.ts
@@ -8,7 +8,6 @@
 import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand } from '@salesforce/sf-plugins-core';
 import { Connection, Messages } from '@salesforce/core';
 import { PackageVersion, PackageVersionCreateRequestResult, getPackageVersionNumber } from '@salesforce/packaging';
-import chalk from 'chalk';
 import { requiredHubFlag } from '../../../../utils/hubFlag.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
@@ -86,7 +85,7 @@ export class PackageVersionCreateListCommand extends SfCommand<CreateListCommand
     if (results.length === 0) {
       this.warn('No results found');
     } else {
-      this.styledHeader(chalk.blue(`Package Version Create Requests  [${results.length}]`));
+      this.styledHeader(`Package Version Create Requests  [${results.length}]`);
       const columnData: ColumnData = {
         Id: {},
         Status: {

--- a/src/commands/package/version/create/report.ts
+++ b/src/commands/package/version/create/report.ts
@@ -5,11 +5,16 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand } from '@salesforce/sf-plugins-core';
+import {
+  Flags,
+  loglevel,
+  orgApiVersionFlagWithDeprecations,
+  SfCommand,
+  StandardColors,
+} from '@salesforce/sf-plugins-core';
 import { Messages, Org } from '@salesforce/core';
 import pkgUtils from '@salesforce/packaging';
 import { PackageVersion, PackageVersionCreateRequestResult } from '@salesforce/packaging';
-import chalk from 'chalk';
 import { camelCaseToTitleCase } from '@salesforce/kit';
 import { requiredHubFlag } from '../../../../utils/hubFlag.js';
 
@@ -106,7 +111,7 @@ export class PackageVersionCreateReportCommand extends SfCommand<ReportCommandRe
       });
     }
 
-    this.styledHeader(chalk.blue('Package Version Create Request'));
+    this.styledHeader('Package Version Create Request');
     this.table(data, {
       key: { header: 'Name' },
       value: { header: 'Value' },
@@ -118,7 +123,7 @@ export class PackageVersionCreateReportCommand extends SfCommand<ReportCommandRe
       record.Error.slice(0, ERROR_LIMIT).forEach((error: string) => {
         errors.push(`(${errors.length + 1}) ${error}`);
       });
-      this.styledHeader(chalk.red('Errors'));
+      this.styledHeader(StandardColors.error('Errors'));
       this.warn(errors.join('\n'));
 
       // Check if errors were truncated.  If so, inform the user with

--- a/src/commands/package/version/report.ts
+++ b/src/commands/package/version/report.ts
@@ -14,7 +14,6 @@ import {
   PackageVersionReportResult,
   PackagingSObjects,
 } from '@salesforce/packaging';
-import chalk from 'chalk';
 import { requiredHubFlag } from '../../../utils/hubFlag.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
@@ -203,7 +202,7 @@ export class PackageVersionReportCommand extends SfCommand<PackageVersionReportR
       );
       displayCoverageRecords.splice(0, displayCoverageRecords.length);
     }
-    this.styledHeader(chalk.blue('Package Version'));
+    this.styledHeader('Package Version');
     this.table(displayRecords, { key: { header: 'Name' }, value: { header: 'Value' } });
     if (displayCoverageRecords.length > 0) {
       this.table(displayCoverageRecords, { key: { header: 'Class Name' }, value: { header: 'Code Coverage' } });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7031,16 +7031,7 @@ srcset@^5.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-5.0.0.tgz#9df6c3961b5b44a02532ce6ae4544832609e2e3f"
   integrity sha512-SqEZaAEhe0A6ETEa9O1IhSPC7MdvehZtCnTR0AftXk3QhY2UNgb+NApFOUPZILXk/YTDfFxMTNJOBpzrJsEdIA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7108,14 +7099,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7666,7 +7650,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7679,15 +7663,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### What does this PR do?
newer plugins don't use blue table hearders (looks kinda sfdx / plugin-source) 
remove chalk dependency

### What issues does this PR fix or reference?
[skip-validate-pr]