### PR TITLE
@W-15398724@ fix: hide codecoverage field in non-verbose query

### DIFF
--- a/src/commands/package/version/list.ts
+++ b/src/commands/package/version/list.ts
@@ -36,7 +36,7 @@ export type PackageVersionListDetails = Omit<
   IsReleased: string | boolean;
   HasPassedCodeCoverageCheck: string | boolean;
   BuildDurationInSeconds: string | number;
-  CodeCoverage: string;
+  CodeCoverage: string | undefined;
   NamespacePrefix: string;
   Package2Name: string;
   Version: string;
@@ -153,7 +153,9 @@ export class PackageVersionListCommand extends SfCommand<PackageVersionListComma
             ? `${record.CodeCoverage.apexCodeCoveragePercentage.toString()}%`
             : Boolean(record.Package2.IsOrgDependent) || record.ValidationSkipped
             ? 'N/A'
-            : '';
+            : flags.verbose
+            ? ''
+            : undefined;
 
         const hasPassedCodeCoverageCheck =
           record.Package2.IsOrgDependent === true || record.ValidationSkipped

--- a/test/commands/package/packageVersion.nut.ts
+++ b/test/commands/package/packageVersion.nut.ts
@@ -389,7 +389,7 @@ describe('package:version:*', () => {
       expect(output).to.have.length.greaterThan(0);
       expect(output[0]).to.have.keys(keys);
       (output as PackageVersionListDetails[])
-        .filter((f: { CodeCoverage: string | boolean }) => f.CodeCoverage)
+        .filter((f: { CodeCoverage: string | undefined }) => f.CodeCoverage)
         .map((v: { SubscriberPackageVersionId: string }) => packageVersionIds.push(v.SubscriberPackageVersionId));
     });
 


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
