### PR TITLE
@W-15398724@ Remove codeCoverage field from non-verbose query response for package version list

### DIFF
--- a/schemas/package-version-list.json
+++ b/schemas/package-version-list.json
@@ -120,6 +120,7 @@
         "Branch",
         "BuildDurationInSeconds",
         "BuildNumber",
+        "CodeCoverage",
         "CreatedBy",
         "CreatedDate",
         "Description",

--- a/schemas/package-version-list.json
+++ b/schemas/package-version-list.json
@@ -120,7 +120,6 @@
         "Branch",
         "BuildDurationInSeconds",
         "BuildNumber",
-        "CodeCoverage",
         "CreatedBy",
         "CreatedDate",
         "Description",

--- a/src/commands/package/version/list.ts
+++ b/src/commands/package/version/list.ts
@@ -36,7 +36,7 @@ export type PackageVersionListDetails = Omit<
   IsReleased: string | boolean;
   HasPassedCodeCoverageCheck: string | boolean;
   BuildDurationInSeconds: string | number;
-  CodeCoverage: string | undefined;
+  CodeCoverage: string;
   NamespacePrefix: string;
   Package2Name: string;
   Version: string;
@@ -148,12 +148,17 @@ export class PackageVersionListCommand extends SfCommand<PackageVersionListComma
           record.AncestorId = 'N/A';
         }
 
-        const codeCoverage =
-          record.CodeCoverage?.apexCodeCoveragePercentage != null
+        function getCodeCoverage(): string {
+          if (flags.verbose) {
+            return 'use --verbose for code coverage';
+          }
+
+          return record.CodeCoverage?.apexCodeCoveragePercentage != null
             ? `${record.CodeCoverage.apexCodeCoveragePercentage.toString()}%`
             : Boolean(record.Package2.IsOrgDependent) || record.ValidationSkipped
             ? 'N/A'
             : '';
+        }
 
         const hasPassedCodeCoverageCheck =
           record.Package2.IsOrgDependent === true || record.ValidationSkipped
@@ -192,7 +197,7 @@ export class PackageVersionListCommand extends SfCommand<PackageVersionListComma
           CreatedDate: new Date(record.CreatedDate).toISOString().replace('T', ' ').substring(0, 16),
           LastModifiedDate: new Date(record.LastModifiedDate).toISOString().replace('T', ' ').substring(0, 16),
           InstallUrl: INSTALL_URL_BASE.toString() + record.SubscriberPackageVersionId,
-          CodeCoverage: flags.verbose ? codeCoverage : undefined,
+          CodeCoverage: getCodeCoverage(),
           HasPassedCodeCoverageCheck: hasPassedCodeCoverageCheck as string | boolean,
           ValidationSkipped: record.ValidationSkipped,
           ValidatedAsync: record.ValidatedAsync,

--- a/src/commands/package/version/list.ts
+++ b/src/commands/package/version/list.ts
@@ -149,7 +149,7 @@ export class PackageVersionListCommand extends SfCommand<PackageVersionListComma
         }
 
         function getCodeCoverage(): string {
-          if (flags.verbose) {
+          if (!flags.verbose) {
             return 'use --verbose for code coverage';
           }
 

--- a/src/commands/package/version/list.ts
+++ b/src/commands/package/version/list.ts
@@ -36,7 +36,7 @@ export type PackageVersionListDetails = Omit<
   IsReleased: string | boolean;
   HasPassedCodeCoverageCheck: string | boolean;
   BuildDurationInSeconds: string | number;
-  CodeCoverage: string;
+  CodeCoverage: string | undefined;
   NamespacePrefix: string;
   Package2Name: string;
   Version: string;
@@ -192,7 +192,7 @@ export class PackageVersionListCommand extends SfCommand<PackageVersionListComma
           CreatedDate: new Date(record.CreatedDate).toISOString().replace('T', ' ').substring(0, 16),
           LastModifiedDate: new Date(record.LastModifiedDate).toISOString().replace('T', ' ').substring(0, 16),
           InstallUrl: INSTALL_URL_BASE.toString() + record.SubscriberPackageVersionId,
-          CodeCoverage: codeCoverage,
+          CodeCoverage: flags.verbose ? codeCoverage : undefined,
           HasPassedCodeCoverageCheck: hasPassedCodeCoverageCheck as string | boolean,
           ValidationSkipped: record.ValidationSkipped,
           ValidatedAsync: record.ValidatedAsync,

--- a/test/commands/package/packageVersion.nut.ts
+++ b/test/commands/package/packageVersion.nut.ts
@@ -309,7 +309,8 @@ describe('package:version:*', () => {
     });
     it('should list package versions in dev hub - json results', () => {
       const command = `package:version:list -v ${session.hubOrg.username} --json`;
-      const output = execCmd<[PackageVersionListCommandResult]>(command, { ensureExitCode: 0 }).jsonOutput?.result;
+      const output = execCmd<PackageVersionListCommandResult>(command, { ensureExitCode: 0 }).jsonOutput
+        ?.result as PackageVersionListCommandResult;
       const keys = [
         'Package2Id',
         'Branch',
@@ -345,7 +346,11 @@ describe('package:version:*', () => {
       ];
       expect(output).to.have.length.greaterThan(0);
       expect(output?.at(0)).to.have.keys(keys);
+      // @ts-ignore
+      const codeCoverage = output?.[0]?.CodeCoverage?.toString() || '';
+      expect(codeCoverage).to.equal('use --verbose for code coverage');
     });
+
     it('should list package versions in dev hub - verbose json results', () => {
       const command = `package:version:list --verbose -v ${session.hubOrg.username} --json`;
       const output = execCmd<PackageVersionListCommandResult>(command, { ensureExitCode: 0 }).jsonOutput

--- a/test/commands/package/packageVersion.nut.ts
+++ b/test/commands/package/packageVersion.nut.ts
@@ -330,7 +330,6 @@ describe('package:version:*', () => {
         'CreatedDate',
         'LastModifiedDate',
         'InstallUrl',
-        'CodeCoverage',
         'ValidationSkipped',
         'ValidatedAsync',
         'AncestorId',
@@ -389,7 +388,7 @@ describe('package:version:*', () => {
       expect(output).to.have.length.greaterThan(0);
       expect(output[0]).to.have.keys(keys);
       (output as PackageVersionListDetails[])
-        .filter((f: { CodeCoverage: string | boolean }) => f.CodeCoverage)
+        .filter((f: { CodeCoverage: string | undefined }) => f.CodeCoverage)
         .map((v: { SubscriberPackageVersionId: string }) => packageVersionIds.push(v.SubscriberPackageVersionId));
     });
 

--- a/test/commands/package/packageVersion.nut.ts
+++ b/test/commands/package/packageVersion.nut.ts
@@ -346,8 +346,7 @@ describe('package:version:*', () => {
       ];
       expect(output).to.have.length.greaterThan(0);
       expect(output?.at(0)).to.have.keys(keys);
-      // @ts-ignore
-      const codeCoverage = output?.[0]?.CodeCoverage?.toString() || '';
+      const codeCoverage = output?.[0]?.CodeCoverage || '';
       expect(codeCoverage).to.equal('use --verbose for code coverage');
     });
 

--- a/test/commands/package/packageVersion.nut.ts
+++ b/test/commands/package/packageVersion.nut.ts
@@ -309,8 +309,7 @@ describe('package:version:*', () => {
     });
     it('should list package versions in dev hub - json results', () => {
       const command = `package:version:list -v ${session.hubOrg.username} --json`;
-      const output = execCmd<PackageVersionListCommandResult>(command, { ensureExitCode: 0 }).jsonOutput
-        ?.result as PackageVersionListCommandResult;
+      const output = execCmd<PackageVersionListCommandResult>(command, { ensureExitCode: 0 }).jsonOutput?.result;
       const keys = [
         'Package2Id',
         'Branch',
@@ -346,7 +345,7 @@ describe('package:version:*', () => {
       ];
       expect(output).to.have.length.greaterThan(0);
       expect(output?.at(0)).to.have.keys(keys);
-      const codeCoverage = output?.[0]?.CodeCoverage || '';
+      const codeCoverage = output?.[0]?.CodeCoverage;
       expect(codeCoverage).to.equal('use --verbose for code coverage');
     });
 

--- a/test/commands/package/packageVersion.nut.ts
+++ b/test/commands/package/packageVersion.nut.ts
@@ -330,6 +330,7 @@ describe('package:version:*', () => {
         'CreatedDate',
         'LastModifiedDate',
         'InstallUrl',
+        'CodeCoverage',
         'ValidationSkipped',
         'ValidatedAsync',
         'AncestorId',
@@ -388,7 +389,7 @@ describe('package:version:*', () => {
       expect(output).to.have.length.greaterThan(0);
       expect(output[0]).to.have.keys(keys);
       (output as PackageVersionListDetails[])
-        .filter((f: { CodeCoverage: string | undefined }) => f.CodeCoverage)
+        .filter((f: { CodeCoverage: string | boolean }) => f.CodeCoverage)
         .map((v: { SubscriberPackageVersionId: string }) => packageVersionIds.push(v.SubscriberPackageVersionId));
     });
 


### PR DESCRIPTION
Ref - [WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001nezqBYAQ)

@W-15398724@

### What does this PR do?
Removing the `codeCoverage` field from the non-verbose query response for `package version list --json`

### What issues does this PR fix or reference?
`codeCoverage` was an empty value for non-verbose response, which is incorrect.
