### PR TITLE
fix: allow some cmds to run outside a project

### DIFF
--- a/src/commands/package/installed/list.ts
+++ b/src/commands/package/installed/list.ts
@@ -34,7 +34,6 @@ export class PackageInstalledListCommand extends SfCommand<PackageInstalledComma
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
   public static readonly aliases = ['force:package:installed:list'];
-  public static readonly requiresProject = true;
 
   public static readonly flags = {
     loglevel,

--- a/src/commands/package/list.ts
+++ b/src/commands/package/list.ts
@@ -39,7 +39,6 @@ export class PackageListCommand extends SfCommand<PackageListCommandResult> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
-  public static readonly requiresProject = true;
   public static readonly deprecateAliases = true;
   public static readonly aliases = ['force:package:list'];
   public static readonly flags = {
@@ -88,7 +87,7 @@ export class PackageListCommand extends SfCommand<PackageListCommandResult> {
               NamespacePrefix,
               ContainerOptions,
               ConvertedFromPackageId,
-              Alias: this.project!.getAliasesFromPackageId(Id).join(),
+              Alias: this.project ? this.project.getAliasesFromPackageId(Id).join() : undefined,
               IsOrgDependent: ContainerOptions === 'Managed' ? 'N/A' : IsOrgDependent ? 'Yes' : 'No',
               PackageErrorUsername,
               AppAnalyticsEnabled,

--- a/src/commands/package/list.ts
+++ b/src/commands/package/list.ts
@@ -9,29 +9,29 @@ import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand } from '@
 import { Messages } from '@salesforce/core/messages';
 import { Package, PackagingSObjects } from '@salesforce/packaging';
 import chalk from 'chalk';
+import { SfProject } from '@salesforce/core';
 import { requiredHubFlag } from '../../utils/hubFlag.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_list');
 
-export type Package2Result = Partial<
-  Pick<
-    PackagingSObjects.Package2,
-    | 'Id'
-    | 'SubscriberPackageId'
-    | 'Name'
-    | 'Description'
-    | 'NamespacePrefix'
-    | 'ContainerOptions'
-    | 'ConvertedFromPackageId'
-    | 'PackageErrorUsername'
-    | 'AppAnalyticsEnabled'
-  > & {
-    Alias: string;
-    CreatedBy: string;
-    IsOrgDependent: string;
-  }
->;
+export type Package2Result = Required<Pick<PackagingSObjects.Package2, 'Id' | 'Name'>> &
+  Partial<
+    Pick<
+      PackagingSObjects.Package2,
+      | 'SubscriberPackageId'
+      | 'Description'
+      | 'NamespacePrefix'
+      | 'ContainerOptions'
+      | 'ConvertedFromPackageId'
+      | 'PackageErrorUsername'
+      | 'AppAnalyticsEnabled'
+    > & {
+      Alias: string;
+      CreatedBy: string;
+      IsOrgDependent: string;
+    }
+  >;
 
 export type PackageListCommandResult = Package2Result[];
 
@@ -50,55 +50,17 @@ export class PackageListCommand extends SfCommand<PackageListCommandResult> {
     }),
   };
 
-  private results: Package2Result[] = [];
-
   public async run(): Promise<PackageListCommandResult> {
     const { flags } = await this.parse(PackageListCommand);
     const connection = flags['target-dev-hub'].getConnection(flags['api-version']);
     const queryResult = await Package.list(connection);
-    this.mapRecordsToResults(queryResult);
-    this.displayResults(flags.verbose, connection.getApiVersion());
-    return this.results;
+    const results = mapRecordsToResults(queryResult);
+    this.displayResults(results, flags.verbose, connection.getApiVersion());
+    return results;
   }
 
-  private mapRecordsToResults(records: PackagingSObjects.Package2[]): void {
-    if (records && records.length > 0) {
-      this.results = records
-        .filter((record) => record.IsDeprecated === false)
-        .map(
-          ({
-            Id,
-            SubscriberPackageId,
-            Name,
-            Description,
-            NamespacePrefix,
-            ContainerOptions,
-            ConvertedFromPackageId,
-            IsOrgDependent,
-            PackageErrorUsername,
-            AppAnalyticsEnabled,
-            CreatedById,
-          }) =>
-            ({
-              Id,
-              SubscriberPackageId,
-              Name,
-              Description,
-              NamespacePrefix,
-              ContainerOptions,
-              ConvertedFromPackageId,
-              Alias: this.project ? this.project.getAliasesFromPackageId(Id).join() : '',
-              IsOrgDependent: ContainerOptions === 'Managed' ? 'N/A' : IsOrgDependent ? 'Yes' : 'No',
-              PackageErrorUsername,
-              AppAnalyticsEnabled,
-              CreatedBy: CreatedById,
-            } as Package2Result)
-        );
-    }
-  }
-
-  private displayResults(verbose = false, apiVersion: string): void {
-    this.styledHeader(chalk.blue(`Packages [${this.results.length}]`));
+  private displayResults(results: Package2Result[], verbose = false, apiVersion: string): void {
+    this.styledHeader(chalk.blue(`Packages [${results.length}]`));
     const columns = {
       NamespacePrefix: { header: messages.getMessage('namespace') },
       Name: { header: messages.getMessage('name') },
@@ -108,26 +70,52 @@ export class PackageListCommand extends SfCommand<PackageListCommandResult> {
       ContainerOptions: {
         header: messages.getMessage('package-type'),
       },
+      ...(verbose
+        ? {
+            SubscriberPackageId: { header: messages.getMessage('package-id') },
+            ConvertedFromPackageId: { header: messages.getMessage('convertedFromPackageId') },
+            IsOrgDependent: { header: messages.getMessage('isOrgDependent') },
+            PackageErrorUsername: { header: messages.getMessage('error-notification-username') },
+            CreatedBy: { header: messages.getMessage('createdBy') },
+          }
+        : {}),
+      ...(verbose && parseInt(apiVersion, 10) >= 59
+        ? { AppAnalyticsEnabled: { header: messages.getMessage('app-analytics-enabled') } }
+        : {}),
     };
 
-    if (verbose) {
-      Object.assign(columns, {
-        SubscriberPackageId: { header: messages.getMessage('package-id') },
-        ConvertedFromPackageId: { header: messages.getMessage('convertedFromPackageId') },
-        IsOrgDependent: { header: messages.getMessage('isOrgDependent') },
-        PackageErrorUsername: { header: messages.getMessage('error-notification-username') },
-      });
-      if (apiVersion >= '59.0') {
-        Object.assign(columns, {
-          AppAnalyticsEnabled: { header: messages.getMessage('app-analytics-enabled') },
-        });
-      }
-      Object.assign(columns, {
-        CreatedBy: {
-          header: messages.getMessage('createdBy'),
-        },
-      });
-    }
-    this.table(this.results, columns);
+    this.table(results, columns);
   }
 }
+
+const mapRecordsToResults = (records: PackagingSObjects.Package2[], project?: SfProject): Package2Result[] =>
+  records
+    .filter((record) => record.IsDeprecated === false)
+    .map(
+      ({
+        Id,
+        SubscriberPackageId,
+        Name,
+        Description,
+        NamespacePrefix,
+        ContainerOptions,
+        ConvertedFromPackageId,
+        IsOrgDependent,
+        PackageErrorUsername,
+        AppAnalyticsEnabled,
+        CreatedById,
+      }) => ({
+        Id,
+        SubscriberPackageId,
+        Name,
+        Description,
+        NamespacePrefix,
+        ContainerOptions,
+        ConvertedFromPackageId,
+        Alias: project ? project.getAliasesFromPackageId(Id).join() : '',
+        IsOrgDependent: ContainerOptions === 'Managed' ? 'N/A' : IsOrgDependent ? 'Yes' : 'No',
+        PackageErrorUsername,
+        AppAnalyticsEnabled,
+        CreatedBy: CreatedById,
+      })
+    );

--- a/src/commands/package/list.ts
+++ b/src/commands/package/list.ts
@@ -87,7 +87,7 @@ export class PackageListCommand extends SfCommand<PackageListCommandResult> {
               NamespacePrefix,
               ContainerOptions,
               ConvertedFromPackageId,
-              Alias: this.project ? this.project.getAliasesFromPackageId(Id).join() : undefined,
+              Alias: this.project ? this.project.getAliasesFromPackageId(Id).join() : '',
               IsOrgDependent: ContainerOptions === 'Managed' ? 'N/A' : IsOrgDependent ? 'Yes' : 'No',
               PackageErrorUsername,
               AppAnalyticsEnabled,

--- a/src/commands/package1/version/create.ts
+++ b/src/commands/package1/version/create.ts
@@ -25,7 +25,6 @@ export class Package1VersionCreateCommand extends SfCommand<PackageUploadRequest
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
-  public static readonly requiresProject = true;
   public static readonly deprecateAliases = true;
   public static readonly aliases = ['force:package1:version:create'];
 

--- a/test/commands/package/packageInstalledList.nut.ts
+++ b/test/commands/package/packageInstalledList.nut.ts
@@ -16,7 +16,6 @@ describe('package:installed:list', () => {
   before(async () => {
     session = await TestSession.create({
       devhubAuthStrategy: 'AUTO',
-      project: { name: 'packageInstalledList' },
     });
   });
 

--- a/test/commands/package/packageList.nut.ts
+++ b/test/commands/package/packageList.nut.ts
@@ -19,7 +19,6 @@ describe('package list', () => {
   before(async () => {
     session = await TestSession.create({
       devhubAuthStrategy: 'AUTO',
-      project: { name: 'packageList' },
     });
     hubOrg = await Org.create({ aliasOrUsername: session.hubOrg.username });
     apiVersion = hubOrg.getConnection().getApiVersion();

--- a/test/commands/package/packageList.nut.ts
+++ b/test/commands/package/packageList.nut.ts
@@ -6,22 +6,22 @@
  */
 
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-import chai from 'chai';
+import { expect, config } from 'chai';
 import { Org } from '@salesforce/core';
 import { Package } from '@salesforce/packaging';
 
-const { expect } = chai;
+config.truncateThreshold = 50_000;
 
 describe('package list', () => {
   let session: TestSession;
   let hubOrg: Org;
-  let apiVersion: string;
+  let apiVersion: number;
   before(async () => {
     session = await TestSession.create({
       devhubAuthStrategy: 'AUTO',
     });
     hubOrg = await Org.create({ aliasOrUsername: session.hubOrg.username });
-    apiVersion = hubOrg.getConnection().getApiVersion();
+    apiVersion = parseInt(hubOrg.getConnection().getApiVersion(), 10);
   });
 
   after(async () => {
@@ -45,7 +45,7 @@ describe('package list', () => {
       'CreatedBy',
       'IsOrgDependent',
     ];
-    if (apiVersion < '59.0') {
+    if (apiVersion < 59) {
       keys.splice(keys.indexOf('AppAnalyticsEnabled'), 1);
     }
     const deprecatedPackages = packages.filter((pkg) => pkg.IsDeprecated);
@@ -66,8 +66,8 @@ describe('package list', () => {
     const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
     expect(output).to.contain('=== Packages');
     let headerExpression =
-      'Namespace Prefix\\s+?Name\\s+?Id\\s+?Alias\\s+?Description\\s+?Type\\s+?Subscriber Package Id\\s+?Converted From Package Id\\s+?Org-Dependent Unlocked Package\\s+?Error Notification Username\\s+?App Analytics Enabled\\s+?Created By';
-    if (apiVersion < '59.0') {
+      'Namespace Prefix\\s+?Name\\s+?Id\\s+?Alias\\s+?Description\\s+?Type\\s+?Subscriber Package Id\\s+?Converted From Package Id\\s+?Org-Dependent Unlocked Package\\s+?Error Notification Username\\s+?Created By\\s+?App Analytics Enabled';
+    if (apiVersion < 59.0) {
       headerExpression = headerExpression.replace('App Analytics Enabled\\s+?', '');
     }
     expect(output).to.match(new RegExp(headerExpression));

--- a/test/commands/package1/versionCreate.nut.ts
+++ b/test/commands/package1/versionCreate.nut.ts
@@ -40,7 +40,6 @@ describe('package1:version:create', () => {
       throw new Error('"ONEGP_TESTKIT_AUTH_URL" env var required for 1gp NUTs');
     }
     session = await TestSession.create({
-      project: { name: 'package1VersionCreate' },
       devhubAuthStrategy: 'AUTO',
     });
 


### PR DESCRIPTION
### What does this PR do?
Allow the following commands to be run outside an sfdx project:
* `package installed list`
* `package list`
* `package1 version create`

the following ones still require an sfdx project:
* package delete
* package update
* package version displayancestry
* package version report
* package version delete
* package version promote

mostly because the packaging lib expects an `SfProject` instance to be able to resolve `--package` being an alias defined in sfdx-project.json.
internal doc: https://salesforce.quip.com/gnuNAtZkcOCP

we haven't decided on this work yet ⬆️ 

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/discussions/2932
@W-16189175@