### PR TITLE
@W-16217108@ fix: cli help text change for async validation

### DIFF
--- a/messages/package_install.md
+++ b/messages/package_install.md
@@ -1,28 +1,28 @@
 # summary
 
-Install a version of a package in the target org.
+Install or upgrade a version of a package in the target org.
 
 # description
 
-To install a package, specify a specific version of the package using the 04t package ID. The package and the version you specified installs in your default target org unless you supply the username for a different target org.
+To install or upgrade a package, specify a specific version of the package using the 04t package ID. The package and the version you specified installs in your default target org unless you supply the username for a different target org.
 
-For package upgrades, to specify options for component deprecation or deletion of removed components, include an --upgrade-type value. To delete components that can be safely deleted and deprecate the others, specify --upgrade-type Mixed (the default). To deprecate all removed components, specify --upgrade-type DeprecateOnly. To delete all removed components, except for custom objects and custom fields, that don't have dependencies, specify --upgrade-type Delete. (Note: This option can result in the loss of data that is associated with the deleted components.) The default is Mixed.
+When upgrading an unlocked package, include --upgrade-type value to specify whether any removed components, are deprecated or deleted. To delete components that can be safely deleted and deprecate the others, specify --upgrade-type Mixed (the default). To deprecate all removed components, specify --upgrade-type DeprecateOnly. To delete all removed components, except for custom objects and custom fields, that don't have dependencies, specify --upgrade-type Delete. (Note: This option can result in the loss of data that is associated with the deleted components.) The default is Mixed.
 
 # examples
 
-- Install a package version with the specified ID in the org with username "me@example.com":
+- Install or upgrade a package version with the specified ID in the org with username "me@example.com":
 
   <%= config.bin %> <%= command.id %> --package 04t... --target-org me@example.com
 
-- Install a package version with the specified alias into your default org:
+- Install or upgrade a package version with the specified alias into your default org:
 
   <%= config.bin %> <%= command.id %> --package awesome_package_alias
 
-- Install a package version with an alias that includes spaces into your default org:
+- Install or upgrade a package version with an alias that includes spaces into your default org:
 
   <%= config.bin %> <%= command.id %> --package "Awesome Package Alias"
 
-- Install an unlocked package version with the specified ID and deprecate all removed components:
+- Upgrade an unlocked package version with the specified ID and deprecate all removed components:
 
   <%= config.bin %> <%= command.id %> --package 04t... --upgrade-type DeprecateOnly
 
@@ -62,7 +62,7 @@ ID (starts with 04t) or alias of the package version to install.
 
 # flags.security-type.summary
 
-Security access type for the installed package. (deprecation notice: The default --security-type value will change from AllUsers to AdminsOnly in v47.0 or later.)
+Security access type for the installed package. Available options are AdminsOnly and AllUsers. The default value is AdminsOnly.
 
 # flags.skip-handlers.summary
 
@@ -78,7 +78,7 @@ Upgrade type for the package installation; available only for unlocked packages.
 
 # flags.upgrade-type.description
 
-For package upgrades, specifies whether to mark all removed components as deprecated (DeprecateOnly), to delete removed components that can be safely deleted and deprecate the others (Mixed), or to delete all removed components, except for custom objects and custom fields, that don't have dependencies (Delete). The default is Mixed. Can specify DeprecateOnly or Delete only for unlocked package upgrades.
+For unlocked package upgrades, specifies whether to mark all removed components as deprecated (DeprecateOnly), to delete removed components that can be safely deleted and deprecate the others (Mixed), or to delete all removed components, except for custom objects and custom fields, that don't have dependencies (Delete). The default is Mixed. Can specify DeprecateOnly or Delete only for unlocked package upgrades.
 
 # flags.apex-compile.summary
 

--- a/messages/package_install.md
+++ b/messages/package_install.md
@@ -62,7 +62,7 @@ ID (starts with 04t) or alias of the package version to install.
 
 # flags.security-type.summary
 
-Security access type for the installed package. Available options are AdminsOnly and AllUsers. The default value is AdminsOnly.
+Security access type for the installed package. Available options are AdminsOnly and AllUsers.
 
 # flags.skip-handlers.summary
 

--- a/messages/package_install.md
+++ b/messages/package_install.md
@@ -6,7 +6,7 @@ Install or upgrade a version of a package in the target org.
 
 To install or upgrade a package, specify a specific version of the package using the 04t package ID. The package and the version you specified installs in your default target org unless you supply the username for a different target org.
 
-When upgrading an unlocked package, include the --upgrade-type value to specify whether any removed components are deprecated or deleted. To delete components that can be safely deleted and deprecate the others, specify "--upgrade-type Mixed" (the default). To deprecate all removed components, specify "--upgrade-type DeprecateOnly". To delete all removed components, except for custom objects and custom fields, that don't have dependencies, specify "--upgrade-type Delete". (Note: This option can result in the loss of data that is associated with the deleted components.) 
+When upgrading an unlocked package, include the --upgrade-type value to specify whether any removed components are deprecated or deleted. To delete components that can be safely deleted and deprecate the others, specify "--upgrade-type Mixed" (the default). To deprecate all removed components, specify "--upgrade-type DeprecateOnly". To delete all removed components, except for custom objects and custom fields, that don't have dependencies, specify "--upgrade-type Delete". (Note: This option can result in the loss of data that is associated with the deleted components.)
 
 # examples
 
@@ -78,7 +78,11 @@ Upgrade type for the package installation; available only for unlocked packages.
 
 # flags.upgrade-type.description
 
-For unlocked package upgrades, specifies whether to mark all removed components as deprecated (DeprecateOnly), to delete removed components that can be safely deleted and deprecate the others (Mixed), or to delete all removed components, except for custom objects and custom fields, that don't have dependencies (Delete). The default is Mixed. Can specify DeprecateOnly or Delete only for unlocked package upgrades.
+For unlocked package upgrades, set this flag to one of these values:
+
+- DeprecateOnly: Mark all removed components as deprecated.
+- Mixed: Delete removed components, except for custom objects and custom fields, that don't have dependencies.
+- Delete: Delete all removed components that can be safely deleted, and deprecate the other components.
 
 # flags.apex-compile.summary
 

--- a/messages/package_install.md
+++ b/messages/package_install.md
@@ -6,7 +6,7 @@ Install or upgrade a version of a package in the target org.
 
 To install or upgrade a package, specify a specific version of the package using the 04t package ID. The package and the version you specified installs in your default target org unless you supply the username for a different target org.
 
-When upgrading an unlocked package, include --upgrade-type value to specify whether any removed components, are deprecated or deleted. To delete components that can be safely deleted and deprecate the others, specify --upgrade-type Mixed (the default). To deprecate all removed components, specify --upgrade-type DeprecateOnly. To delete all removed components, except for custom objects and custom fields, that don't have dependencies, specify --upgrade-type Delete. (Note: This option can result in the loss of data that is associated with the deleted components.) The default is Mixed.
+When upgrading an unlocked package, include the --upgrade-type value to specify whether any removed components are deprecated or deleted. To delete components that can be safely deleted and deprecate the others, specify "--upgrade-type Mixed" (the default). To deprecate all removed components, specify "--upgrade-type DeprecateOnly". To delete all removed components, except for custom objects and custom fields, that don't have dependencies, specify "--upgrade-type Delete". (Note: This option can result in the loss of data that is associated with the deleted components.) 
 
 # examples
 

--- a/messages/package_version_create.md
+++ b/messages/package_version_create.md
@@ -49,6 +49,10 @@ Path to the directory that contains the contents of the package.
 
 Path to a definition file similar to scratch org definition file that contains the list of features and org preferences that the metadata of the package version depends on.
 
+# flags.definition-file.description
+
+For a patch version, the features specified in this file are ignored, and instead the features specified for the ancestor version are used.
+
 # flags.branch.summary
 
 Name of the branch in your source control system that the package version is based on.
@@ -214,8 +218,8 @@ Version create.
 # packageVersionCreatePerformingValidations
 
 The validations for this package version are in progress, but you can now begin testing this package version.
-To determine whether all package validations completed successfully, run sf package version create report and review the Async Validation Status.
-Async validated package versions can be promoted only if all validations completed successfully.
+To determine whether all package validations complete successfully, run "sf package version create report --package-create-request-id 08cxx" and review the Status.
+Async validated package versions can be promoted only if all validations complete successfully.
 
 # packageVersionCreateFinalStatus
 

--- a/messages/package_version_delete.md
+++ b/messages/package_version_delete.md
@@ -1,10 +1,10 @@
 # summary
 
-Delete a package version. In second-generation managed packaging, only beta package versions can be deleted. Before deleting a package version, review the considerations outlined in https://developer.salesforce.com/docs/atlas.en-us.pkg2_dev.meta/pkg2_dev/sfdx_dev_dev2gp_package_deletion.htm.
+Delete a package version.
 
 # description
 
-Specify the ID or alias of the package version you want to delete.
+Specify the ID or alias of the package version you want to delete. In second-generation managed packaging, only beta package versions can be deleted. Before deleting a package version, review the considerations outlined in https://developer.salesforce.com/docs/atlas.en-us.pkg2_dev.meta/pkg2_dev/sfdx_dev_dev2gp_package_deletion.htm.
 
 # examples
 

--- a/messages/package_version_delete.md
+++ b/messages/package_version_delete.md
@@ -1,6 +1,6 @@
 # summary
 
-Delete a package version.
+Delete a package version. In second-generation managed packaging, only beta package versions can be deleted. Before deleting a package version, review the considerations outlined in https://developer.salesforce.com/docs/atlas.en-us.pkg2_dev.meta/pkg2_dev/sfdx_dev_dev2gp_package_deletion.htm.
 
 # description
 

--- a/src/commands/package/version/create.ts
+++ b/src/commands/package/version/create.ts
@@ -62,6 +62,7 @@ export class PackageVersionCreateCommand extends SfCommand<PackageVersionCommand
       aliases: ['definitionfile'],
       char: 'f',
       summary: messages.getMessage('flags.definition-file.summary'),
+      description: messages.getMessage('flags.definition-file.description'),
     }),
     'installation-key': Flags.string({
       deprecateAliases: true,


### PR DESCRIPTION
@W-16217108@ - [WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001wQOe3YAG/view)

### What does this PR do?
In this PR the Help text that displays with packageVersionCreatePerformingValidations and edited the definition-file flag was updated. These changes were requested by Dileep and handled by @penelopy
