### PR TITLE
Add specifier for message

### DIFF
--- a/messages/package_delete.md
+++ b/messages/package_delete.md
@@ -48,7 +48,7 @@ The request to delete this package was canceled
 
 # humanSuccess
 
-Successfully deleted the package.
+Successfully deleted the package. %s
 
 # humanSuccessUndelete
 

--- a/messages/package_delete.md
+++ b/messages/package_delete.md
@@ -48,7 +48,7 @@ The request to delete this package was canceled
 
 # humanSuccess
 
-Successfully deleted the package. %s
+Successfully deleted the package with id: %s
 
 # humanSuccessUndelete
 

--- a/messages/package_delete.md
+++ b/messages/package_delete.md
@@ -48,7 +48,7 @@ The request to delete this package was canceled
 
 # humanSuccess
 
-Successfully deleted the package with id: %s
+Successfully deleted the package with ID: %s
 
 # humanSuccessUndelete
 

--- a/messages/package_version_delete.md
+++ b/messages/package_version_delete.md
@@ -46,7 +46,7 @@ The request to delete this package version has been canceled.
 
 # humanSuccess
 
-Successfully deleted the package version. %s
+Successfully deleted the package version with id: %s
 
 # humanSuccessUndelete
 

--- a/messages/package_version_delete.md
+++ b/messages/package_version_delete.md
@@ -46,7 +46,7 @@ The request to delete this package version has been canceled.
 
 # humanSuccess
 
-Successfully deleted the package version.
+Successfully deleted the package version. %s
 
 # humanSuccessUndelete
 

--- a/messages/package_version_delete.md
+++ b/messages/package_version_delete.md
@@ -46,7 +46,7 @@ The request to delete this package version has been canceled.
 
 # humanSuccess
 
-Successfully deleted the package version with id: %s
+Successfully deleted the package version with ID: %s
 
 # humanSuccessUndelete
 

--- a/test/commands/package/packageCreateAndDelete.nut.ts
+++ b/test/commands/package/packageCreateAndDelete.nut.ts
@@ -51,7 +51,7 @@ describe('package create/update/delete', () => {
     it('should delete a package - human readable results', () => {
       const command = `package:delete -p ${pkgName} -v ${session.hubOrg.username} --no-prompt`;
       const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
-      expect(output).to.contain('Successfully deleted the package with id: 0Ho');
+      expect(output).to.contain('Successfully deleted the package with ID: 0Ho');
     });
   });
   describe('create/update/delete - json results', () => {

--- a/test/commands/package/packageCreateAndDelete.nut.ts
+++ b/test/commands/package/packageCreateAndDelete.nut.ts
@@ -51,7 +51,7 @@ describe('package create/update/delete', () => {
     it('should delete a package - human readable results', () => {
       const command = `package:delete -p ${pkgName} -v ${session.hubOrg.username} --no-prompt`;
       const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
-      expect(output).to.contain('Successfully deleted the package. 0Ho');
+      expect(output).to.contain('Successfully deleted the package with id: 0Ho');
     });
   });
   describe('create/update/delete - json results', () => {

--- a/test/commands/package/packageVersion.nut.ts
+++ b/test/commands/package/packageVersion.nut.ts
@@ -443,7 +443,7 @@ describe('package:version:*', () => {
       const id = deletableVersionIds.pop();
       const command = `package:version:delete -p ${id} --noprompt`;
       const result = execCmd<[PackageSaveResult]>(command, { ensureExitCode: 0 }).shellOutput.stdout;
-      expect(result).to.contain(`Successfully deleted the package version with id: ${id}`);
+      expect(result).to.contain(`Successfully deleted the package version with ID: ${id}`);
     });
   });
 

--- a/test/commands/package/packageVersion.nut.ts
+++ b/test/commands/package/packageVersion.nut.ts
@@ -443,7 +443,7 @@ describe('package:version:*', () => {
       const id = deletableVersionIds.pop();
       const command = `package:version:delete -p ${id} --noprompt`;
       const result = execCmd<[PackageSaveResult]>(command, { ensureExitCode: 0 }).shellOutput.stdout;
-      expect(result).to.contain(`Successfully deleted the package version. ${id}`);
+      expect(result).to.contain(`Successfully deleted the package version with id: ${id}`);
     });
   });
 

--- a/test/commands/package/version.delete.test.ts
+++ b/test/commands/package/version.delete.test.ts
@@ -93,7 +93,7 @@ describe('package:version:delete', () => {
     const results: PackageSaveResult = await command.run();
     expect(results.id).to.equal('testId');
     expect(uxSuccessStub.calledOnce).to.be.true;
-    expect(uxSuccessStub.args[0][0]).to.equal('Successfully deleted the package version. testId');
+    expect(uxSuccessStub.args[0][0]).to.equal('Successfully deleted the package version with id: testId');
     expect(results.id).to.equal('testId');
   });
   it('should undelete a package version', async () => {

--- a/test/commands/package/version.delete.test.ts
+++ b/test/commands/package/version.delete.test.ts
@@ -93,7 +93,7 @@ describe('package:version:delete', () => {
     const results: PackageSaveResult = await command.run();
     expect(results.id).to.equal('testId');
     expect(uxSuccessStub.calledOnce).to.be.true;
-    expect(uxSuccessStub.args[0][0]).to.equal('Successfully deleted the package version with id: testId');
+    expect(uxSuccessStub.args[0][0]).to.equal('Successfully deleted the package version with ID: testId');
     expect(results.id).to.equal('testId');
   });
   it('should undelete a package version', async () => {


### PR DESCRIPTION
### What does this PR do?
We will be changing how `util.format` works when formatting messages. 
Specifiers (eg `%s`) will be required for the data to be rendered. As is, it appends data if no matching specifier is found.

### What issues does this PR fix or reference?
More info here: https://github.com/forcedotcom/sfdx-core/pull/1099
[@W-16197665@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-16197665)
