### PR TITLE
feat: remove outdated version create message

### DIFF
--- a/messages/package_version_promote.md
+++ b/messages/package_version_promote.md
@@ -38,7 +38,7 @@ Don't prompt to confirm setting the package version as released.
 
 # humanSuccess
 
-Successfully promoted the package version, ID: %s, to released. Starting in Winter ‘21, only unlocked package versions that have met the minimum 75% code coverage requirement can be promoted. Code coverage minimums aren’t enforced on org-dependent unlocked packages.
+Successfully promoted the package version, ID: %s, to released.
 
 # previouslyReleasedMessage
 

--- a/test/commands/package/versionPromoteUpdate.nut.ts
+++ b/test/commands/package/versionPromoteUpdate.nut.ts
@@ -80,9 +80,7 @@ describe('package:version:promote / package:version:update', () => {
     }).shellOutput.stdout;
     expect(result).to.contain('Successfully promoted the package version');
     expect(result).to.contain('04t', result);
-    expect(result).to.contain(
-      'to released. Starting in Winter ‘21, only unlocked package versions that have met the minimum 75% code coverage requirement can be promoted. Code coverage minimums aren’t enforced on org-dependent unlocked packages.'
-    );
+    expect(result).to.contain('to released.');
   });
 
   it('should promote a package (--json)', () => {


### PR DESCRIPTION
### What does this PR do?

Removes an old message about code coverage requirements for promoting unlocked package versions. The information is several years old.

### What issues does this PR fix or reference?

It was a simple enough change that I didn't bother opening an issue.