### PR TITLE
W-18491179: expose package convert command for ga

### DIFF
--- a/src/commands/package/convert.ts
+++ b/src/commands/package/convert.ts
@@ -28,7 +28,6 @@ export class PackageConvert extends SfCommand<PackageVersionCreateRequestResult>
   public static readonly examples = messages.getMessages('examples');
   public static readonly deprecateAliases = true;
   public static readonly aliases = ['force:package:convert'];
-  public static readonly hidden = true;
   public static readonly flags = {
     loglevel,
     'target-dev-hub': requiredHubFlag,
@@ -90,7 +89,6 @@ export class PackageConvert extends SfCommand<PackageVersionCreateRequestResult>
       char: 'a',
       deprecateAliases: true,
       aliases: ['patchversion'],
-      hidden: true,
     }),
   };
 


### PR DESCRIPTION
### What does this PR do?

In preparation for 2GP GA, this PR exposes the "sf package convert" command via the CLI. It also exposes the --patch-version option.

Timelines for release:
June 4th - available as RC (Release Candidate)
June 11th - CLI Commands GA
June 14th (R2b) Core Code GA

### What issues does this PR fix or reference?

@W-18491179@ Expose Conversions / Migrations CLI commands at GA
