### PR TITLE
fix: filter displayRecord

### DIFF
--- a/src/commands/package/version/create/list.ts
+++ b/src/commands/package/version/create/list.ts
@@ -94,7 +94,15 @@ export class PackageVersionCreateListCommand extends SfCommand<CreateListCommand
       this.table({ data, overflow: 'wrap', title: chalk.blue(`Package Version Create Requests  [${results.length}]`) });
     }
 
-    return results;
+    // Filter out unwanted fields from JSON output
+    // TotalNumberOfMetadataFiles and TotalSizeOfMetadataFiles are intentionally excluded from display
+    const filteredResults = results.map((r) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { TotalNumberOfMetadataFiles, TotalSizeOfMetadataFiles, ...filteredResult } = r;
+      return filteredResult;
+    });
+
+    return filteredResults as CreateListCommandResult;
   }
 
   // Queries Package2Version for the name and version number of the packages and adds that data

--- a/test/commands/package/versionPromoteUpdate.nut.ts
+++ b/test/commands/package/versionPromoteUpdate.nut.ts
@@ -57,7 +57,9 @@ describe('package:version:promote / package:version:update', () => {
       'CreatedBy',
       'ConvertedFromVersionId',
       'CodeCoverage',
-      'VersionNumber'
+      'VersionNumber',
+      'TotalNumberOfMetadataFiles',
+      'TotalSizeOfMetadataFiles'
     );
     expect(result?.Id).to.match(/08c.{15}/);
     expect(result?.Package2Id).to.match(/0Ho.{15}/);


### PR DESCRIPTION
### What does this PR do?
Filters display record to exclude fields TotalNumberOfMetadataFiles and TotalSizeOfMetadataFiles for package:version:create:list command.

### What issues does this PR fix or reference?
@W-19132026
