### PR TITLE
feat: accept 15-char package version IDs in bundle definition file

### DIFF
--- a/src/commands/package/bundle/version/create.ts
+++ b/src/commands/package/bundle/version/create.ts
@@ -24,11 +24,77 @@ import {
 import { Messages, Lifecycle } from '@salesforce/core';
 import { camelCaseToTitleCase, Duration } from '@salesforce/kit';
 import { requiredHubFlag } from '../../../../utils/hubFlag.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 // TODO: Update messages
 const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'bundle_version_create');
 export type BundleVersionCreate = BundleSObjects.PackageBundleVersionCreateRequestResult;
+
+/**
+ * Converts a 15-character Salesforce ID to its 18-character equivalent.
+ * If the ID is already 18 characters or not a valid Salesforce ID format, returns it unchanged.
+ *
+ * @param id - The Salesforce ID to convert
+ * @returns The 18-character Salesforce ID
+ */
+function convertTo18CharId(id: string): string {
+  // If already 18 chars or not 15 chars, return as-is
+  if (!id || id.length !== 15) {
+    return id;
+  }
+
+  // Salesforce ID conversion algorithm
+  // For each chunk of 5 characters, calculate a checksum character
+  const suffix: string[] = [];
+
+  for (let i = 0; i < 3; i++) {
+    let flags = 0;
+    for (let j = 0; j < 5; j++) {
+      const char = id.charAt(i * 5 + j);
+      // Check if character is uppercase (A-Z have higher ASCII values than lowercase)
+      if (char >= 'A' && char <= 'Z') {
+        flags += 1 << j;
+      }
+    }
+    // Convert flags to a base-32 character
+    suffix.push('ABCDEFGHIJKLMNOPQRSTUVWXYZ012345'.charAt(flags));
+  }
+
+  return id + suffix.join('');
+}
+
+/**
+ * Normalizes package version IDs in a bundle definition object.
+ * Converts any 15-character package version IDs to 18-character format.
+ *
+ * @param obj - The object to normalize (can be nested)
+ * @returns The normalized object
+ */
+function normalizePackageVersionIds(obj: unknown): unknown {
+  if (typeof obj !== 'object' || obj === null) {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => normalizePackageVersionIds(item));
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === 'packageVersion' && typeof value === 'string' && value.startsWith('04t')) {
+      // Normalize package version IDs (04t prefix)
+      result[key] = convertTo18CharId(value);
+    } else if (typeof value === 'object') {
+      result[key] = normalizePackageVersionIds(value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
 
 export class PackageBundlesCreate extends SfCommand<BundleSObjects.PackageBundleVersionCreateRequestResult> {
   public static readonly hidden = true;
@@ -81,11 +147,38 @@ export class PackageBundlesCreate extends SfCommand<BundleSObjects.PackageBundle
       minorVersion = versionParts[1] || '';
     }
 
+    // Read and normalize the definition file to handle 15-char package version IDs
+    let definitionFilePath = flags['definition-file'];
+    let tempFilePath: string | undefined;
+
+    try {
+      // Read the definition file
+      const definitionContent = await fs.promises.readFile(definitionFilePath, 'utf8');
+      const definitionJson = JSON.parse(definitionContent) as unknown;
+
+      // Normalize any 15-character package version IDs to 18-character format
+      const normalizedJson = normalizePackageVersionIds(definitionJson);
+
+      // Check if any normalization occurred by comparing stringified versions
+      if (JSON.stringify(definitionJson) !== JSON.stringify(normalizedJson)) {
+        // Create a temporary file with normalized content
+        const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'sf-bundle-'));
+        tempFilePath = path.join(tempDir, 'normalized-definition.json');
+        await fs.promises.writeFile(tempFilePath, JSON.stringify(normalizedJson, null, 2), 'utf8');
+        definitionFilePath = tempFilePath;
+        this.debug(`Normalized package version IDs in definition file. Using temporary file: ${tempFilePath}`);
+      }
+    } catch (error) {
+      // If reading/parsing fails, let the packaging library handle the error
+      // This preserves the original error messages for invalid JSON, missing files, etc.
+      this.debug(`Could not normalize definition file: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
     const options: BundleVersionCreateOptions = {
       connection: flags['target-dev-hub'].getConnection(flags['api-version']),
       project: this.project!,
       PackageBundle: flags.bundle,
-      BundleVersionComponentsPath: flags['definition-file'],
+      BundleVersionComponentsPath: definitionFilePath,
       Description: flags.description,
       MajorVersion: majorVersion,
       MinorVersion: minorVersion,
@@ -134,6 +227,20 @@ export class PackageBundlesCreate extends SfCommand<BundleSObjects.PackageBundle
         this.spinner.stop();
       }
       throw error;
+    } finally {
+      // Clean up temporary file if it was created
+      if (tempFilePath) {
+        try {
+          const tempDir = path.dirname(tempFilePath);
+          await fs.promises.rm(tempDir, { recursive: true, force: true });
+          this.debug(`Cleaned up temporary definition file: ${tempFilePath}`);
+        } catch (cleanupError) {
+          // Log but don't fail if cleanup fails
+          this.debug(
+            `Failed to clean up temporary file: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+          );
+        }
+      }
     }
 
     // Stop spinner only if it was started - stop it cleanly without a message

--- a/src/commands/package/bundle/version/create.ts
+++ b/src/commands/package/bundle/version/create.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand } from '@salesforce/sf-plugins-core';
 import {
   BundleVersionCreateOptions,
@@ -24,9 +27,6 @@ import {
 import { Messages, Lifecycle } from '@salesforce/core';
 import { camelCaseToTitleCase, Duration } from '@salesforce/kit';
 import { requiredHubFlag } from '../../../../utils/hubFlag.js';
-import fs from 'node:fs';
-import path from 'node:path';
-import os from 'node:os';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 // TODO: Update messages
@@ -148,31 +148,7 @@ export class PackageBundlesCreate extends SfCommand<BundleSObjects.PackageBundle
     }
 
     // Read and normalize the definition file to handle 15-char package version IDs
-    let definitionFilePath = flags['definition-file'];
-    let tempFilePath: string | undefined;
-
-    try {
-      // Read the definition file
-      const definitionContent = await fs.promises.readFile(definitionFilePath, 'utf8');
-      const definitionJson = JSON.parse(definitionContent) as unknown;
-
-      // Normalize any 15-character package version IDs to 18-character format
-      const normalizedJson = normalizePackageVersionIds(definitionJson);
-
-      // Check if any normalization occurred by comparing stringified versions
-      if (JSON.stringify(definitionJson) !== JSON.stringify(normalizedJson)) {
-        // Create a temporary file with normalized content
-        const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'sf-bundle-'));
-        tempFilePath = path.join(tempDir, 'normalized-definition.json');
-        await fs.promises.writeFile(tempFilePath, JSON.stringify(normalizedJson, null, 2), 'utf8');
-        definitionFilePath = tempFilePath;
-        this.debug(`Normalized package version IDs in definition file. Using temporary file: ${tempFilePath}`);
-      }
-    } catch (error) {
-      // If reading/parsing fails, let the packaging library handle the error
-      // This preserves the original error messages for invalid JSON, missing files, etc.
-      this.debug(`Could not normalize definition file: ${error instanceof Error ? error.message : String(error)}`);
-    }
+    const { definitionFilePath, tempFilePath } = await this.normalizeDefinitionFile(flags['definition-file']);
 
     const options: BundleVersionCreateOptions = {
       connection: flags['target-dev-hub'].getConnection(flags['api-version']),
@@ -228,29 +204,57 @@ export class PackageBundlesCreate extends SfCommand<BundleSObjects.PackageBundle
       }
       throw error;
     } finally {
-      // Clean up temporary file if it was created
-      if (tempFilePath) {
-        try {
-          const tempDir = path.dirname(tempFilePath);
-          await fs.promises.rm(tempDir, { recursive: true, force: true });
-          this.debug(`Cleaned up temporary definition file: ${tempFilePath}`);
-        } catch (cleanupError) {
-          // Log but don't fail if cleanup fails
-          this.debug(
-            `Failed to clean up temporary file: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-          );
-        }
-      }
+      await this.cleanupTempFile(tempFilePath);
     }
 
-    // Stop spinner only if it was started - stop it cleanly without a message
     if (isSpinnerRunning) {
       this.spinner.stop();
     }
 
+    this.handleResult(result);
+    return result;
+  }
+
+  private async normalizeDefinitionFile(
+    definitionFilePath: string
+  ): Promise<{ definitionFilePath: string; tempFilePath?: string }> {
+    try {
+      const definitionContent = await fs.promises.readFile(definitionFilePath, 'utf8');
+      const definitionJson = JSON.parse(definitionContent) as unknown;
+      const normalizedJson = normalizePackageVersionIds(definitionJson);
+
+      if (JSON.stringify(definitionJson) !== JSON.stringify(normalizedJson)) {
+        const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'sf-bundle-'));
+        const tempFilePath = path.join(tempDir, 'normalized-definition.json');
+        await fs.promises.writeFile(tempFilePath, JSON.stringify(normalizedJson, null, 2), 'utf8');
+        this.debug(`Normalized package version IDs in definition file. Using temporary file: ${tempFilePath}`);
+        return { definitionFilePath: tempFilePath, tempFilePath };
+      }
+    } catch (error) {
+      this.debug(`Could not normalize definition file: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    return { definitionFilePath };
+  }
+
+  private async cleanupTempFile(tempFilePath: string | undefined): Promise<void> {
+    if (tempFilePath) {
+      try {
+        const tempDir = path.dirname(tempFilePath);
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
+        this.debug(`Cleaned up temporary definition file: ${tempFilePath}`);
+      } catch (cleanupError) {
+        this.debug(
+          `Failed to clean up temporary file: ${
+            cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
+          }`
+        );
+      }
+    }
+  }
+
+  private handleResult(result: BundleSObjects.PackageBundleVersionCreateRequestResult): void {
     switch (result.RequestStatus) {
       case BundleSObjects.PkgBundleVersionCreateReqStatus.error: {
-        // Collect all error messages from both Error array and ValidationError
         const errorMessages: string[] = [];
 
         if (result.Error && result.Error.length > 0) {
@@ -267,7 +271,6 @@ export class PackageBundlesCreate extends SfCommand<BundleSObjects.PackageBundle
         throw messages.createError('multipleErrors', [errorText]);
       }
       case BundleSObjects.PkgBundleVersionCreateReqStatus.success: {
-        // Show the PackageBundleVersionId (1Q8) if available, otherwise show the request ID
         const displayId = result.PackageBundleVersionId || result.Id;
         this.log(`Successfully created bundle version with ID ${displayId}`);
         break;
@@ -275,6 +278,5 @@ export class PackageBundlesCreate extends SfCommand<BundleSObjects.PackageBundle
       default:
         this.log(messages.getMessage('InProgress', [camelCaseToTitleCase(result.RequestStatus as string), result.Id]));
     }
-    return result;
   }
 }

--- a/test/commands/bundle/packageBundleVersionCreate.test.ts
+++ b/test/commands/bundle/packageBundleVersionCreate.test.ts
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { Config } from '@oclif/core';
 import { assert, expect } from 'chai';
@@ -20,9 +23,6 @@ import { PackageBundleVersion, BundleSObjects } from '@salesforce/packaging';
 import sinon from 'sinon';
 import { SfCommand } from '@salesforce/sf-plugins-core';
 import { PackageBundlesCreate } from '../../../src/commands/package/bundle/version/create.js';
-import fs from 'node:fs';
-import path from 'node:path';
-import os from 'node:os';
 
 const pkgBundleVersionCreateErrorResult: BundleSObjects.PackageBundleVersionCreateRequestResult = {
   Id: '08c3i000000fylXXXX',
@@ -243,8 +243,14 @@ describe('package:bundle:version:create - tests', () => {
     });
 
     it('should normalize 15-character package version IDs to 18-character format', async () => {
-      createStub = $$.SANDBOX.stub(PackageBundleVersion, 'create');
-      createStub.resolves(pkgBundleVersionCreateSuccessResult);
+      // Capture the file content inside the stub, before the command cleans up temp files
+      let capturedContent: string | undefined;
+      createStub = $$.SANDBOX.stub(PackageBundleVersion, 'create').callsFake(
+        async (opts: { BundleVersionComponentsPath: string }) => {
+          capturedContent = await fs.promises.readFile(opts.BundleVersionComponentsPath, 'utf8');
+          return pkgBundleVersionCreateSuccessResult;
+        }
+      );
 
       // Create a temporary definition file with 15-char IDs
       const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'test-bundle-'));
@@ -265,16 +271,9 @@ describe('package:bundle:version:create - tests', () => {
         stubSpinner(cmd);
         await cmd.run();
 
-        // Verify that PackageBundleVersion.create was called
         expect(createStub.callCount).to.equal(1);
-
-        // Get the options passed to create
-        const createOptions = createStub.firstCall.args[0] as { BundleVersionComponentsPath: string };
-        const usedDefinitionPath = createOptions.BundleVersionComponentsPath;
-
-        // Read the file that was passed to the create method
-        const usedContent = await fs.promises.readFile(usedDefinitionPath, 'utf8');
-        const usedJson = JSON.parse(usedContent) as typeof definitionContent;
+        assert(capturedContent, 'Expected file content to be captured');
+        const usedJson = JSON.parse(capturedContent) as typeof definitionContent;
 
         // Verify that the 15-char ID was converted to 18-char
         expect(usedJson.components[0].packageVersion).to.equal('04t5f000000WM9yAAG');
@@ -287,8 +286,14 @@ describe('package:bundle:version:create - tests', () => {
     });
 
     it('should handle nested packageVersion fields in definition file', async () => {
-      createStub = $$.SANDBOX.stub(PackageBundleVersion, 'create');
-      createStub.resolves(pkgBundleVersionCreateSuccessResult);
+      // Capture the file content inside the stub, before the command cleans up temp files
+      let capturedContent: string | undefined;
+      createStub = $$.SANDBOX.stub(PackageBundleVersion, 'create').callsFake(
+        async (opts: { BundleVersionComponentsPath: string }) => {
+          capturedContent = await fs.promises.readFile(opts.BundleVersionComponentsPath, 'utf8');
+          return pkgBundleVersionCreateSuccessResult;
+        }
+      );
 
       // Create a temporary definition file with nested structure
       const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'test-bundle-'));
@@ -311,17 +316,12 @@ describe('package:bundle:version:create - tests', () => {
         stubSpinner(cmd);
         await cmd.run();
 
-        // Get the options passed to create
-        const createOptions = createStub.firstCall.args[0] as { BundleVersionComponentsPath: string };
-        const usedDefinitionPath = createOptions.BundleVersionComponentsPath;
-
-        // Read the file that was passed to the create method
-        const usedContent = await fs.promises.readFile(usedDefinitionPath, 'utf8');
-        const usedJson = JSON.parse(usedContent) as typeof definitionContent;
+        assert(capturedContent, 'Expected file content to be captured');
+        const usedJson = JSON.parse(capturedContent) as typeof definitionContent;
 
         // Verify that both 15-char IDs were converted
         expect(usedJson.bundle.components[0].packageVersion).to.equal('04t5f000000WM9yAAG');
-        expect(usedJson.bundle.components[1].nested.packageVersion).to.equal('04t5f000000WM9zAAG');
+        expect(usedJson.bundle.components[1].nested!.packageVersion).to.equal('04t5f000000WM9zAAG');
       } finally {
         // Clean up
         await fs.promises.rm(tempDir, { recursive: true, force: true });

--- a/test/commands/bundle/packageBundleVersionCreate.test.ts
+++ b/test/commands/bundle/packageBundleVersionCreate.test.ts
@@ -20,6 +20,9 @@ import { PackageBundleVersion, BundleSObjects } from '@salesforce/packaging';
 import sinon from 'sinon';
 import { SfCommand } from '@salesforce/sf-plugins-core';
 import { PackageBundlesCreate } from '../../../src/commands/package/bundle/version/create.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 
 const pkgBundleVersionCreateErrorResult: BundleSObjects.PackageBundleVersionCreateRequestResult = {
   Id: '08c3i000000fylXXXX',
@@ -236,6 +239,124 @@ describe('package:bundle:version:create - tests', () => {
             'SampleDataController: Invalid type: Schema.Property__c\n' +
             'SampleDataController: Invalid type: Schema.Broker__c'
         );
+      }
+    });
+
+    it('should normalize 15-character package version IDs to 18-character format', async () => {
+      createStub = $$.SANDBOX.stub(PackageBundleVersion, 'create');
+      createStub.resolves(pkgBundleVersionCreateSuccessResult);
+
+      // Create a temporary definition file with 15-char IDs
+      const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'test-bundle-'));
+      const definitionFile = path.join(tempDir, 'definition.json');
+      const definitionContent = {
+        components: [
+          { packageVersion: '04t5f000000WM9y' }, // 15-char ID
+          { packageVersion: '04t5f000000WM9yAAG' }, // 18-char ID (should not change)
+        ],
+      };
+      await fs.promises.writeFile(definitionFile, JSON.stringify(definitionContent, null, 2), 'utf8');
+
+      try {
+        const cmd = new PackageBundlesCreate(
+          ['-b', 'TestBundle', '-p', definitionFile, '--target-dev-hub', 'test@hub.org'],
+          config
+        );
+        stubSpinner(cmd);
+        await cmd.run();
+
+        // Verify that PackageBundleVersion.create was called
+        expect(createStub.callCount).to.equal(1);
+
+        // Get the options passed to create
+        const createOptions = createStub.firstCall.args[0] as { BundleVersionComponentsPath: string };
+        const usedDefinitionPath = createOptions.BundleVersionComponentsPath;
+
+        // Read the file that was passed to the create method
+        const usedContent = await fs.promises.readFile(usedDefinitionPath, 'utf8');
+        const usedJson = JSON.parse(usedContent) as typeof definitionContent;
+
+        // Verify that the 15-char ID was converted to 18-char
+        expect(usedJson.components[0].packageVersion).to.equal('04t5f000000WM9yAAG');
+        // Verify that the 18-char ID remained unchanged
+        expect(usedJson.components[1].packageVersion).to.equal('04t5f000000WM9yAAG');
+      } finally {
+        // Clean up
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should handle nested packageVersion fields in definition file', async () => {
+      createStub = $$.SANDBOX.stub(PackageBundleVersion, 'create');
+      createStub.resolves(pkgBundleVersionCreateSuccessResult);
+
+      // Create a temporary definition file with nested structure
+      const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'test-bundle-'));
+      const definitionFile = path.join(tempDir, 'definition.json');
+      const definitionContent = {
+        bundle: {
+          components: [
+            { packageVersion: '04t5f000000WM9y' }, // 15-char ID
+            { nested: { packageVersion: '04t5f000000WM9z' } }, // nested 15-char ID
+          ],
+        },
+      };
+      await fs.promises.writeFile(definitionFile, JSON.stringify(definitionContent, null, 2), 'utf8');
+
+      try {
+        const cmd = new PackageBundlesCreate(
+          ['-b', 'TestBundle', '-p', definitionFile, '--target-dev-hub', 'test@hub.org'],
+          config
+        );
+        stubSpinner(cmd);
+        await cmd.run();
+
+        // Get the options passed to create
+        const createOptions = createStub.firstCall.args[0] as { BundleVersionComponentsPath: string };
+        const usedDefinitionPath = createOptions.BundleVersionComponentsPath;
+
+        // Read the file that was passed to the create method
+        const usedContent = await fs.promises.readFile(usedDefinitionPath, 'utf8');
+        const usedJson = JSON.parse(usedContent) as typeof definitionContent;
+
+        // Verify that both 15-char IDs were converted
+        expect(usedJson.bundle.components[0].packageVersion).to.equal('04t5f000000WM9yAAG');
+        expect(usedJson.bundle.components[1].nested.packageVersion).to.equal('04t5f000000WM9zAAG');
+      } finally {
+        // Clean up
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should not modify definition file when no 15-char IDs are present', async () => {
+      createStub = $$.SANDBOX.stub(PackageBundleVersion, 'create');
+      createStub.resolves(pkgBundleVersionCreateSuccessResult);
+
+      // Create a temporary definition file with only 18-char IDs
+      const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'test-bundle-'));
+      const definitionFile = path.join(tempDir, 'definition.json');
+      const definitionContent = {
+        components: [{ packageVersion: '04t5f000000WM9yAAG' }], // 18-char ID
+      };
+      await fs.promises.writeFile(definitionFile, JSON.stringify(definitionContent, null, 2), 'utf8');
+
+      try {
+        const cmd = new PackageBundlesCreate(
+          ['-b', 'TestBundle', '-p', definitionFile, '--target-dev-hub', 'test@hub.org'],
+          config
+        );
+        stubSpinner(cmd);
+        await cmd.run();
+
+        // Get the options passed to create
+        const createOptions = createStub.firstCall.args[0] as { BundleVersionComponentsPath: string };
+        const usedDefinitionPath = createOptions.BundleVersionComponentsPath;
+
+        // The path should be the original file since no normalization was needed
+        expect(usedDefinitionPath).to.equal(definitionFile);
+      } finally {
+        // Clean up
+        await fs.promises.rm(tempDir, { recursive: true, force: true });
       }
     });
   });


### PR DESCRIPTION
## Summary
- Adds automatic conversion of 15-character Salesforce package version IDs (04t prefix) to 18-character format when reading bundle definition files
- Creates a temporary normalized definition file only when conversion is needed, preserving the original file
- Includes cleanup of temporary files in a `finally` block

## Test plan
- [x] Unit test: 15-char IDs are normalized to 18-char format
- [x] Unit test: nested `packageVersion` fields are handled recursively
- [x] Unit test: definition files with only 18-char IDs are passed through unchanged (no temp file created)
- [ ] Manual test with a real bundle definition file containing 15-char `04t` IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)