### PR TITLE
fix: remove stray semicolon from README title, fix typo in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -8,7 +8,7 @@ NOTICE: While GitHub is the preferred channel for reporting issues/feedback, thi
 -->
 
 <!--
-FOR BUGS RELATED TO THE SALEFORCE CLI, please use this repository: https://github.com/forcedotcom/cli/issues
+FOR BUGS RELATED TO THE SALESFORCE CLI, please use this repository: https://github.com/forcedotcom/cli/issues
 -->
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# plugin-packaging;
+# plugin-packaging
 
 [![NPM](https://img.shields.io/npm/v/@salesforce/plugin-packaging.svg?label=@salesforce/plugin-packaging)](https://www.npmjs.com/package/@salesforce/plugin-packaging) [![Downloads/week](https://img.shields.io/npm/dw/@salesforce/plugin-packaging.svg)](https://npmjs.org/package/@salesforce/plugin-packaging) [![License](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://opensource.org/license/apache-2-0)
 


### PR DESCRIPTION
## Summary

- **README.md**: Remove trailing semicolon from the title (`# plugin-packaging;` → `# plugin-packaging`)
- **`.github/ISSUE_TEMPLATE/Bug_report.md`**: Fix typo `SALEFORCE` → `SALESFORCE`