### PR TITLE
fix: add no-prompt flag to package install NUT-W-22403408

### DIFF
--- a/test/commands/package/install.nut.ts
+++ b/test/commands/package/install.nut.ts
@@ -42,7 +42,7 @@ describe('package install', () => {
   });
 
   it('should install DreamhouseLWC package with polling', () => {
-    const command = 'package:install -p 04tKY000000MF7uYAG -w 20';
+    const command = 'package:install -p 04tKY000000MF7uYAG -w 20 --no-prompt';
     const output = execCmd(command, { ensureExitCode: 0, timeout: Duration.minutes(20).milliseconds }).shellOutput
       .stdout;
     expect(output).to.contain('Successfully installed package');


### PR DESCRIPTION
### What does this PR do?                                                                                                                                                                                  
 Added `--no-prompt` flag to skip the prompt and auto-enable RSS in CI                                                                                
✅: run test:nuts locally and test passed                                                                                        
                                                                   

### What issues does this PR fix or reference?
@W-22403408@