### PR TITLE
@W-21771476: feat: display HasVpi in package version list and report commands [DO NOT MERGE until 6/4 262.8 deploy]

### DIFF
--- a/messages/package_version_list.md
+++ b/messages/package_version_list.md
@@ -157,3 +157,7 @@ Language
 # endToEndBuildDurationInSeconds
 
 End To End Build Duration In Seconds
+
+# hasVpi
+
+Has Version Settings

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@oclif/core": "^4",
     "@salesforce/core": "^8.31.0",
     "@salesforce/kit": "^3.2.6",
-    "@salesforce/packaging": "^4.24.3",
+    "@salesforce/packaging": "^4.25.0",
     "@salesforce/sf-plugins-core": "^12.2.22",
     "chalk": "^5.6.2"
   },

--- a/schemas/package-version-list.json
+++ b/schemas/package-version-list.json
@@ -111,6 +111,9 @@
         },
         "Language": {
           "type": "string"
+        },
+        "HasVpi": {
+          "type": ["string", "boolean"]
         }
       },
       "required": [

--- a/schemas/package-version-report.json
+++ b/schemas/package-version-report.json
@@ -17,10 +17,7 @@
           ]
         },
         "HasPassedCodeCoverageCheck": {
-          "type": [
-            "boolean",
-            "string"
-          ]
+          "type": ["boolean", "string"]
         },
         "Package2": {
           "type": "object",
@@ -96,10 +93,7 @@
           ]
         },
         "HasMetadataRemoved": {
-          "type": [
-            "boolean",
-            "string"
-          ]
+          "type": ["boolean", "string"]
         },
         "Id": {
           "type": "string"
@@ -201,32 +195,23 @@
               "$ref": "#/definitions/PackagingSObjects.SubscriberPackageDependencies"
             }
           },
-          "required": [
-            "Dependencies"
-          ],
+          "required": ["Dependencies"],
           "additionalProperties": false
         },
         "Version": {
           "type": "string"
         },
         "AncestorVersion": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "AncestorId": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
+        },
+        "HasVpi": {
+          "type": ["boolean", "string"]
         }
       },
-      "required": [
-        "HasMetadataRemoved",
-        "Package2",
-        "Version"
-      ]
+      "required": ["HasMetadataRemoved", "Package2", "Version"]
     },
     "CodeCoverage": {
       "anyOf": [
@@ -240,19 +225,14 @@
               "type": "number"
             }
           },
-          "required": [
-            "apexCodeCoveragePercentage"
-          ],
+          "required": ["apexCodeCoveragePercentage"],
           "additionalProperties": false
         }
       ]
     },
     "PackageType": {
       "type": "string",
-      "enum": [
-        "Managed",
-        "Unlocked"
-      ]
+      "enum": ["Managed", "Unlocked"]
     },
     "CodeCoveragePercentages": {
       "anyOf": [
@@ -274,19 +254,14 @@
                     "type": "number"
                   }
                 },
-                "required": [
-                  "className",
-                  "codeCoveragePercentage"
-                ],
+                "required": ["className", "codeCoveragePercentage"],
                 "additionalProperties": false
               },
               "minItems": 1,
               "maxItems": 1
             }
           },
-          "required": [
-            "codeCovPercentages"
-          ],
+          "required": ["codeCovPercentages"],
           "additionalProperties": false
         }
       ]
@@ -303,16 +278,12 @@
                 "type": "string"
               }
             },
-            "required": [
-              "subscriberPackageVersionId"
-            ],
+            "required": ["subscriberPackageVersionId"],
             "additionalProperties": false
           }
         }
       },
-      "required": [
-        "ids"
-      ],
+      "required": ["ids"],
       "additionalProperties": false
     }
   }

--- a/src/commands/package/version/list.ts
+++ b/src/commands/package/version/list.ts
@@ -41,6 +41,7 @@ export type PackageVersionListDetails = Omit<
   | 'BuildDurationInSeconds'
   | 'CodeCoverage'
   | 'Package2'
+  | 'HasVpi'
 > & {
   HasMetadataRemoved: string;
   IsPasswordProtected: string | boolean;
@@ -57,6 +58,7 @@ export type PackageVersionListDetails = Omit<
   IsOrgDependent: 'N/A' | 'Yes' | 'No';
   CreatedBy: string;
   ValidatedAsync?: boolean;
+  HasVpi?: string | boolean;
 };
 
 export type PackageVersionListCommandResult = PackageVersionListDetails[];
@@ -187,6 +189,13 @@ export class PackageVersionListCommand extends SfCommand<PackageVersionListComma
         const hasMetadataRemoved =
           containerOptionsMap.get(record.Package2Id) !== 'Managed' ? 'N/A' : record.HasMetadataRemoved ? 'Yes' : 'No';
 
+        const hasVpi =
+          record.HasVpi === undefined
+            ? undefined
+            : containerOptionsMap.get(record.Package2Id) !== 'Managed'
+            ? 'N/A'
+            : String(record.HasVpi); // displays 'true'/'false'
+
         results.push({
           Package2Id: record.Package2Id,
           Branch: record.Branch,
@@ -222,6 +231,7 @@ export class PackageVersionListCommand extends SfCommand<PackageVersionListComma
           HasMetadataRemoved: hasMetadataRemoved,
           CreatedBy: record.CreatedById,
           Language: record.Language,
+          HasVpi: hasVpi,
         });
       });
       this.table({
@@ -287,6 +297,7 @@ const getColumnData = (
       { key: 'Description', name: messages.getMessage('description') },
       { key: 'CodeCoverage', name: messages.getMessage('codeCoverage') },
       { key: 'HasPassedCodeCoverageCheck', name: messages.getMessage('hasPassedCodeCoverageCheck') },
+      { key: 'HasVpi', name: messages.getMessage('hasVpi') },
       { key: 'ConvertedFromVersionId', name: messages.getMessage('convertedFromVersionId') },
       { key: 'IsOrgDependent', name: messages.getMessage('isOrgDependent') },
       { key: 'ReleaseVersion', name: messages.getMessage('releaseVersion') },

--- a/src/commands/package/version/report.ts
+++ b/src/commands/package/version/report.ts
@@ -308,7 +308,7 @@ export class PackageVersionReportCommand extends SfCommand<PackageVersionReportR
     record.HasMetadataRemoved = results.PackageType !== 'Managed' ? 'N/A' : results.HasMetadataRemoved ? 'Yes' : 'No';
 
     if (results.HasVpi !== undefined) {
-      record.HasVpi = results.PackageType !== 'Managed' ? 'N/A' : results.HasVpi ? 'Yes' : 'No';
+      record.HasVpi = results.PackageType !== 'Managed' ? 'N/A' : String(results.HasVpi);
     }
 
     record.ConvertedFromVersionId ??= ' ';

--- a/src/commands/package/version/report.ts
+++ b/src/commands/package/version/report.ts
@@ -39,6 +39,7 @@ const omissions = [
   'Package2',
   'HasMetadataRemoved',
   'DeveloperUsePkgZip',
+  'HasVpi',
 ] as const;
 type Omission = (typeof omissions)[number];
 
@@ -48,6 +49,7 @@ export type PackageVersionReportResultModified = Omit<PackageVersionReportResult
   Package2: Partial<Omit<PackagingSObjects.Package2, 'IsOrgDependent'> & { IsOrgDependent: string }>;
   PackageType?: PackageType;
   HasMetadataRemoved: boolean | string;
+  HasVpi?: boolean | string;
 };
 
 export class PackageVersionReportCommand extends SfCommand<PackageVersionReportResultModified> {
@@ -85,6 +87,7 @@ export class PackageVersionReportCommand extends SfCommand<PackageVersionReportR
     return massagedResults;
   }
 
+  // eslint-disable-next-line complexity
   private display(record: PackageVersionReportResultModified, verbose: boolean, connection: Connection): void {
     if (this.jsonEnabled()) {
       return;
@@ -197,6 +200,12 @@ export class PackageVersionReportCommand extends SfCommand<PackageVersionReportR
             : '') as unknown as string,
         }
       );
+      if (Number(connection.version) >= 67) {
+        displayRecords.push({
+          key: pvlMessages.getMessage('hasVpi'),
+          value: record.HasVpi,
+        });
+      }
     }
     const maximumNumClasses = 15; // Number of least code covered classes displayed on the cli output for better UX.
     let codeCovStr = ''; // String to display when code coverage data is empty or null
@@ -297,6 +306,10 @@ export class PackageVersionReportCommand extends SfCommand<PackageVersionReportR
 
     // set HasMetadataRemoved to N/A for Unlocked, and No when value is false or absent (pre-230)
     record.HasMetadataRemoved = results.PackageType !== 'Managed' ? 'N/A' : results.HasMetadataRemoved ? 'Yes' : 'No';
+
+    if (results.HasVpi !== undefined) {
+      record.HasVpi = results.PackageType !== 'Managed' ? 'N/A' : results.HasVpi ? 'Yes' : 'No';
+    }
 
     record.ConvertedFromVersionId ??= ' ';
 

--- a/test/commands/package/packageVersion.nut.ts
+++ b/test/commands/package/packageVersion.nut.ts
@@ -418,6 +418,10 @@ describe('package:version:*', () => {
         'HasMetadataRemoved',
         'CreatedBy',
       ];
+      // HasVpi is only present at API v67+ (app version 262)
+      if (Number((session.hubOrg as { apiVersion?: string }).apiVersion) >= 67) {
+        keys.push('HasVpi');
+      }
 
       expect(output).to.have.length.greaterThan(0);
       expect(output[0]).to.have.keys(keys);

--- a/test/commands/package/versionReport.test.ts
+++ b/test/commands/package/versionReport.test.ts
@@ -200,7 +200,7 @@ describe('package:version:report - tests', () => {
       pvrrm.Package2.IsOrgDependent = 'N/A';
       pvrrm.CodeCoverage = { apexCodeCoveragePercentage: 33 };
       pvrrm.HasMetadataRemoved = 'Yes';
-      pvrrm.HasVpi = 'Yes';
+      pvrrm.HasVpi = 'true';
       pvrrm.HasPassedCodeCoverageCheck = 'N/A';
 
       const result = cmd['massageResultsForDisplay'](pvrr);

--- a/test/commands/package/versionReport.test.ts
+++ b/test/commands/package/versionReport.test.ts
@@ -46,6 +46,7 @@ const pkgVersionReportResultModified: PackageVersionReportResultModified = {
   Description: '',
   HasMetadataRemoved: 'N/A',
   HasPassedCodeCoverageCheck: false,
+  HasVpi: 'N/A',
   Id: '05i3i000000Gmj6XXX',
   InstallKey: '',
   IsDeleted: false,
@@ -93,6 +94,7 @@ const pkgVersionReportResult: PackageVersionReportResult = {
   Description: '',
   HasMetadataRemoved: false,
   HasPassedCodeCoverageCheck: false,
+  HasVpi: false,
   Id: '05i3i000000Gmj6XXX',
   InstallKey: '',
   IsDeleted: false,
@@ -189,6 +191,7 @@ describe('package:version:report - tests', () => {
       pvrr.PackageType = 'Managed';
       pvrr.CodeCoverage = { apexCodeCoveragePercentage: 33 };
       pvrr.HasMetadataRemoved = true;
+      pvrr.HasVpi = true;
       pvrr.Description = 'test description';
       const pvrrm = Object.assign({} as PackageVersionReportResultModified, pvrr) as PackageVersionReportResultModified;
       pvrrm.Version = '0.0.6.0';
@@ -197,6 +200,7 @@ describe('package:version:report - tests', () => {
       pvrrm.Package2.IsOrgDependent = 'N/A';
       pvrrm.CodeCoverage = { apexCodeCoveragePercentage: 33 };
       pvrrm.HasMetadataRemoved = 'Yes';
+      pvrrm.HasVpi = 'Yes';
       pvrrm.HasPassedCodeCoverageCheck = 'N/A';
 
       const result = cmd['massageResultsForDisplay'](pvrr);
@@ -208,6 +212,7 @@ describe('package:version:report - tests', () => {
       pvrr.PackageType = undefined;
       pvrr.CodeCoverage = { apexCodeCoveragePercentage: 33 };
       pvrr.HasMetadataRemoved = true;
+      pvrr.HasVpi = false;
       pvrr.Package2.IsOrgDependent = true;
       pvrr.ValidationSkipped = true;
       const pvrrm = Object.assign({} as PackageVersionReportResultModified, pvrr) as PackageVersionReportResultModified;
@@ -217,10 +222,18 @@ describe('package:version:report - tests', () => {
       pvrrm.Package2.IsOrgDependent = 'No';
       pvrrm.CodeCoverage = 'N/A';
       pvrrm.HasMetadataRemoved = 'N/A';
+      pvrrm.HasVpi = 'N/A';
       pvrrm.HasPassedCodeCoverageCheck = 'N/A';
 
       const result = cmd['massageResultsForDisplay'](pvrr);
       expect(result).to.deep.equal(pvrrm);
+    });
+    it('should not transform HasVpi when undefined (api < 67)', () => {
+      const pvrr = Object.assign({}, pkgVersionReportResult);
+      delete (pvrr as Partial<PackageVersionReportResult>).HasVpi;
+
+      const result = cmd['massageResultsForDisplay'](pvrr);
+      expect(result.HasVpi).to.be.undefined;
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,10 +1574,10 @@
   dependencies:
     "@salesforce/ts-types" "^2.0.12"
 
-"@salesforce/packaging@^4.24.3":
-  version "4.24.3"
-  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-4.24.3.tgz#e148fd73e20f264f9d04f796c1a1809c9453a706"
-  integrity sha512-PqLpjyYId1Fjbpl6I6gvvDwRuvgXLVtWMvUDE8a1lYhAi7OhqRaxw0o5NZ/wAp/DyqG02j3q4kwlw1iMFyzt/Q==
+"@salesforce/packaging@^4.25.0":
+  version "4.25.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/packaging/-/packaging-4.25.0.tgz#e9f65226368ed9dd03c884417c06f1fa50b6e010"
+  integrity sha512-3yAC34sCm699FROy7Ijt7FEC4uuHZFHPdWazDeBgmPGVMY57AEBrNCBEP1L23uI1LfzjjpA0xXQf2D/Bdv5WQw==
   dependencies:
     "@jsforce/jsforce-node" "^3.10.15"
     "@salesforce/core" "^8.31.0"


### PR DESCRIPTION
@W-21771476@

## Summary
- Display `HasVpi` field in `sf package version list --verbose` and `sf package version report`
- Version-gated at API v67+ (column/row absent at lower versions)
- List displays `'true'`/`'false'`/`'N/A'` (unlocked); Report displays `'Yes'`/`'No'`/`'N/A'`
- JSON schemas updated

## Dependencies
- Requires [forcedotcom/packaging#875](https://github.com/forcedotcom/packaging/pull/875) to merge first (publishes new `@salesforce/packaging` version)
- Requires W-21771475 (262.8 patch) to be fully deployed (scheduled 6/4)
- After packaging merges, this PR needs a dep bump commit before merge

## Test plan
- [x] Unit tests: report massage transforms (managed→Yes, unlocked→N/A, undefined stays undefined)
- [x] Schema validation passing
- [x] NUT: HasVpi key present in verbose json output (conditional on org API version)
- [x] Manual testing on 262 devhub (hub0318) and 260 devhub (hub1215)

🤖 Generated with [Claude Code](https://claude.com/claude-code)