### PR TITLE
@W-23253606: allow node version override in npm publish

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -30,4 +30,5 @@ jobs:
       sign: true
       tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
+      nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- Adds `nodeVersion: ${{ vars.NODE_VERSION_OVERRIDE }}` to the `onRelease.yml` workflow to allow overriding the Node version used during npm publish
- Mirrors the fix in https://github.com/salesforcecli/plugin-templates/pull/977

## References
@W-23253606@