### PR TITLE
feat: add package trust link approve command

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -360,6 +360,14 @@
   },
   {
     "alias": [],
+    "command": "package:trust:link:approve",
+    "flagAliases": ["apiversion", "targetusername", "u"],
+    "flagChars": ["a", "o", "r"],
+    "flags": ["api-version", "authoring-org", "flags-dir", "json", "loglevel", "request", "target-org"],
+    "plugin": "@salesforce/plugin-packaging"
+  },
+  {
+    "alias": [],
     "command": "package:trust:link:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["o", "s"],

--- a/messages/package_trust_link_approve.md
+++ b/messages/package_trust_link_approve.md
@@ -1,0 +1,29 @@
+# summary
+
+Approve a Public Secure trust link request.
+
+# description
+
+Run this command against a verified packaging org (PBO) to accept a pending VerifiedDev trust request from an authoring org. Identify the request with either --request or --authoring-org.
+
+# examples
+
+- Approve a trust request by the request ID returned from package trust link list:
+
+  <%= config.bin %> <%= command.id %> --request 2vtxx0000000001AAA --target-org myPbo
+
+- Approve a trust request by its authoring org ID:
+
+  <%= config.bin %> <%= command.id %> --authoring-org 00Dxx0000009zZZEAY --target-org myPbo
+
+# flags.request.summary
+
+ID of the pending trust link request to approve.
+
+# flags.authoring-org.summary
+
+Authoring org ID of the pending trust link request to approve.
+
+# output
+
+Approved trust link request %s from Authoring Org %s.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@oclif/core": "^4",
     "@salesforce/core": "^9.1.0",
     "@salesforce/kit": "^4.0.0",
-    "@salesforce/packaging": "5.0.9-spi.3",
+    "@salesforce/packaging": "5.0.9-spi.4",
     "@salesforce/sf-plugins-core": "^13.0.0",
     "@salesforce/ts-types": "^3.0.1",
     "chalk": "^5.6.2"

--- a/schemas/package-trust-link-approve.json
+++ b/schemas/package-trust-link-approve.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/PackageTrustLinkApproveResult",
+  "definitions": {
+    "PackageTrustLinkApproveResult": {
+      "type": "object",
+      "properties": {
+        "LinkRequestId": {
+          "type": "string"
+        },
+        "AuthoringOrgId": {
+          "type": "string"
+        },
+        "VerifiedOrgId": {
+          "type": "string"
+        },
+        "Status": {
+          "type": "string",
+          "const": "Accepted"
+        }
+      },
+      "required": ["LinkRequestId", "AuthoringOrgId", "VerifiedOrgId", "Status"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/commands/package/trust/link/approve.ts
+++ b/src/commands/package/trust/link/approve.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Messages } from '@salesforce/core';
+import { PackageTrustLink, PackageTrustLinkApproveOptions, PackageTrustLinkApproveResult } from '@salesforce/packaging';
+import {
+  Flags,
+  loglevel,
+  orgApiVersionFlagWithDeprecations,
+  requiredOrgFlagWithDeprecations,
+  SfCommand,
+} from '@salesforce/sf-plugins-core';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_trust_link_approve');
+
+export class PackageTrustLinkApproveCommand extends SfCommand<PackageTrustLinkApproveResult> {
+  public static readonly hidden = true;
+  public static state = 'beta';
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly flags = {
+    loglevel,
+    'target-org': requiredOrgFlagWithDeprecations,
+    'api-version': orgApiVersionFlagWithDeprecations,
+    request: Flags.salesforceId({
+      char: 'r',
+      startsWith: '2vt',
+      length: 'both',
+      exactlyOne: ['request', 'authoring-org'],
+      summary: messages.getMessage('flags.request.summary'),
+    }),
+    'authoring-org': Flags.salesforceId({
+      char: 'a',
+      startsWith: '00D',
+      length: 'both',
+      exactlyOne: ['request', 'authoring-org'],
+      summary: messages.getMessage('flags.authoring-org.summary'),
+    }),
+  };
+
+  public async run(): Promise<PackageTrustLinkApproveResult> {
+    const { flags } = await this.parse(PackageTrustLinkApproveCommand);
+    const connection = flags['target-org'].getConnection(flags['api-version']);
+    const options: PackageTrustLinkApproveOptions = flags.request
+      ? { requestId: flags.request }
+      : { authoringOrgId: flags['authoring-org'] };
+    const result = await PackageTrustLink.approve(connection, options);
+
+    this.log(messages.getMessage('output', [result.LinkRequestId, result.AuthoringOrgId]));
+    return result;
+  }
+}

--- a/test/commands/package/packageTrustLinkApprove.test.ts
+++ b/test/commands/package/packageTrustLinkApprove.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Config } from '@oclif/core';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+import { PackageTrustLink, PackageTrustLinkApproveResult } from '@salesforce/packaging';
+import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { PackageTrustLinkApproveCommand } from '../../../src/commands/package/trust/link/approve.js';
+
+const requestId = '2vtxx0000000001AAA';
+const authoringOrgId = '00Dxx0000009zZZEAY';
+const approveResult: PackageTrustLinkApproveResult = {
+  LinkRequestId: requestId,
+  AuthoringOrgId: authoringOrgId,
+  VerifiedOrgId: '00Dxx0000001gPLEAY',
+  Status: 'Accepted',
+};
+
+describe('package:trust:link:approve - tests', () => {
+  const $$ = new TestContext();
+  const testOrg = new MockTestOrgData();
+  const config = new Config({ root: import.meta.url });
+  let approveStub: sinon.SinonStub;
+  let sfCommandStubs: ReturnType<typeof stubSfCommandUx>;
+
+  beforeEach(async () => {
+    await $$.stubAuths(testOrg);
+    await config.load();
+    approveStub = $$.SANDBOX.stub(PackageTrustLink, 'approve').resolves(approveResult);
+    sfCommandStubs = stubSfCommandUx($$.SANDBOX);
+  });
+
+  afterEach(() => {
+    $$.restore();
+  });
+
+  it('approves a trust link selected by request ID', async () => {
+    const command = new PackageTrustLinkApproveCommand(
+      ['--request', requestId, '--target-org', testOrg.username, '--api-version', '68.0'],
+      config
+    );
+
+    const result = await command.run();
+
+    expect(result).to.deep.equal(approveResult);
+    expect(approveStub.firstCall.args[1]).to.deep.equal({ requestId });
+    expect(sfCommandStubs.log.firstCall.args[0]).to.contain(requestId);
+  });
+
+  it('approves a trust link selected by authoring org', async () => {
+    const command = new PackageTrustLinkApproveCommand(
+      ['--authoring-org', authoringOrgId, '--target-org', testOrg.username],
+      config
+    );
+
+    await command.run();
+
+    expect(approveStub.firstCall.args[1]).to.deep.equal({ authoringOrgId });
+  });
+
+  it('requires a selector', async () => {
+    const command = new PackageTrustLinkApproveCommand(['--target-org', testOrg.username], config);
+    try {
+      await command.run();
+      expect.fail('expected exactly-one flag validation to fail');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+    }
+    expect(approveStub.called).to.equal(false);
+  });
+
+  it('rejects multiple selectors', async () => {
+    const command = new PackageTrustLinkApproveCommand(
+      ['--request', requestId, '--authoring-org', authoringOrgId, '--target-org', testOrg.username],
+      config
+    );
+    try {
+      await command.run();
+      expect.fail('expected exactly-one flag validation to fail');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+    }
+    expect(approveStub.called).to.equal(false);
+  });
+
+  it('rejects an invalid authoring org ID before calling the library', async () => {
+    const command = new PackageTrustLinkApproveCommand(
+      ['--authoring-org', 'not-an-org', '--target-org', testOrg.username],
+      config
+    );
+
+    try {
+      await command.run();
+      expect.fail('expected invalid org ID validation to fail');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+    }
+    expect(approveStub.called).to.equal(false);
+  });
+
+  it('rejects a request ID with the wrong entity prefix before calling the library', async () => {
+    const command = new PackageTrustLinkApproveCommand(
+      ['--request', authoringOrgId, '--target-org', testOrg.username],
+      config
+    );
+
+    try {
+      await command.run();
+      expect.fail('expected invalid request ID validation to fail');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+    }
+    expect(approveStub.called).to.equal(false);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1368,10 +1368,10 @@
   dependencies:
     "@salesforce/ts-types" "^3.0.0"
 
-"@salesforce/packaging@5.0.9-spi.3":
-  version "5.0.9-spi.3"
-  resolved "https://registry.npmjs.org/@salesforce/packaging/-/packaging-5.0.9-spi.3.tgz#1bb93927b9466a181d81d6c859faa748bc6871ea"
-  integrity sha512-gREgMZTb5vcvp2ygIDXCCvNlxUQSHhMWdGcSsALH2V7DLVrn9rWxOSLIXp3YEROe/42fe2q2aZ6OVaAxccwKVQ==
+"@salesforce/packaging@5.0.9-spi.4":
+  version "5.0.9-spi.4"
+  resolved "https://registry.npmjs.org/@salesforce/packaging/-/packaging-5.0.9-spi.4.tgz#1e57e6fe03ddfb45d285f4273eb02326c306bd9c"
+  integrity sha512-6G/47Hn4QYpfPn1vljDqt/UIntAdW40cQ1OxClAegJK5K5PH+n/2/Ng6skTDpnF0gIOBMxZOzKQZOwCvY3KkLg==
   dependencies:
     "@jsforce/jsforce-node" "^3.10.19"
     "@salesforce/core" "^9.0.0"


### PR DESCRIPTION
## Summary
- add beta `sf package trust link approve` for verified PBO admins
- require exactly one of `--request <2vt...>` or `--authoring-org <00D...>` and delegate approval to `PackageTrustLink.approve`
- return an Accepted result with command output, JSON schema, and command snapshot coverage
- consume `@salesforce/packaging@5.0.9-spi.4` from [forcedotcom/packaging#921](https://github.com/forcedotcom/packaging/pull/921)

## Test plan
- [x] clean `yarn install --frozen-lockfile` from the public npm URL
- [x] `yarn test`
- [x] request-ID and authoring-org selector unit tests
- [x] missing, conflicting, and wrong-prefix selector validation