### PR TITLE
feat: add package trust link deny command

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -368,6 +368,14 @@
   },
   {
     "alias": [],
+    "command": "package:trust:link:deny",
+    "flagAliases": ["apiversion", "targetusername", "u"],
+    "flagChars": ["a", "o", "r"],
+    "flags": ["api-version", "authoring-org", "flags-dir", "json", "loglevel", "request", "target-org"],
+    "plugin": "@salesforce/plugin-packaging"
+  },
+  {
+    "alias": [],
     "command": "package:trust:link:list",
     "flagAliases": ["apiversion", "targetusername", "u"],
     "flagChars": ["o", "s"],

--- a/messages/package_trust_link_deny.md
+++ b/messages/package_trust_link_deny.md
@@ -1,0 +1,31 @@
+# summary
+
+Deny a Public Secure trust link request.
+
+# description
+
+Run this command against a verified packaging org (PBO) to decline a pending VerifiedDev trust request from an authoring org. Identify the request with either --request or --authoring-org.
+
+A denied request stays on the org as Declined. The authoring org can unlink and request again.
+
+# examples
+
+- Deny a trust request by the request ID returned from package trust link list:
+
+  <%= config.bin %> <%= command.id %> --request 2vtxx0000000001AAA --target-org myPbo
+
+- Deny a trust request by its authoring org ID:
+
+  <%= config.bin %> <%= command.id %> --authoring-org 00Dxx0000009zZZEAY --target-org myPbo
+
+# flags.request.summary
+
+ID of the pending trust link request to deny.
+
+# flags.authoring-org.summary
+
+Authoring org ID of the pending trust link request to deny.
+
+# output
+
+Denied trust link request %s from Authoring Org %s.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@oclif/core": "^4",
     "@salesforce/core": "^9.1.0",
     "@salesforce/kit": "^4.0.0",
-    "@salesforce/packaging": "5.0.9-spi.4",
+    "@salesforce/packaging": "5.0.9-spi.5",
     "@salesforce/sf-plugins-core": "^13.0.0",
     "@salesforce/ts-types": "^3.0.1",
     "chalk": "^5.6.2"

--- a/schemas/package-trust-link-deny.json
+++ b/schemas/package-trust-link-deny.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/PackageTrustLinkDenyResult",
+  "definitions": {
+    "PackageTrustLinkDenyResult": {
+      "type": "object",
+      "properties": {
+        "LinkRequestId": {
+          "type": "string"
+        },
+        "AuthoringOrgId": {
+          "type": "string"
+        },
+        "VerifiedOrgId": {
+          "type": "string"
+        },
+        "Status": {
+          "type": "string",
+          "const": "Declined"
+        }
+      },
+      "required": ["LinkRequestId", "AuthoringOrgId", "VerifiedOrgId", "Status"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/commands/package/trust/link/deny.ts
+++ b/src/commands/package/trust/link/deny.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Messages } from '@salesforce/core';
+import { PackageTrustLink, PackageTrustLinkDenyOptions, PackageTrustLinkDenyResult } from '@salesforce/packaging';
+import {
+  Flags,
+  loglevel,
+  orgApiVersionFlagWithDeprecations,
+  requiredOrgFlagWithDeprecations,
+  SfCommand,
+} from '@salesforce/sf-plugins-core';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-packaging', 'package_trust_link_deny');
+
+export class PackageTrustLinkDenyCommand extends SfCommand<PackageTrustLinkDenyResult> {
+  public static readonly hidden = true;
+  public static state = 'beta';
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly flags = {
+    loglevel,
+    'target-org': requiredOrgFlagWithDeprecations,
+    'api-version': orgApiVersionFlagWithDeprecations,
+    request: Flags.salesforceId({
+      char: 'r',
+      startsWith: '2vt',
+      length: 'both',
+      exactlyOne: ['request', 'authoring-org'],
+      summary: messages.getMessage('flags.request.summary'),
+    }),
+    'authoring-org': Flags.salesforceId({
+      char: 'a',
+      startsWith: '00D',
+      length: 'both',
+      exactlyOne: ['request', 'authoring-org'],
+      summary: messages.getMessage('flags.authoring-org.summary'),
+    }),
+  };
+
+  public async run(): Promise<PackageTrustLinkDenyResult> {
+    const { flags } = await this.parse(PackageTrustLinkDenyCommand);
+    const connection = flags['target-org'].getConnection(flags['api-version']);
+    const options: PackageTrustLinkDenyOptions = flags.request
+      ? { requestId: flags.request }
+      : { authoringOrgId: flags['authoring-org'] };
+    const result = await PackageTrustLink.deny(connection, options);
+
+    this.log(messages.getMessage('output', [result.LinkRequestId, result.AuthoringOrgId]));
+    return result;
+  }
+}

--- a/test/commands/package/packageTrustLinkDeny.test.ts
+++ b/test/commands/package/packageTrustLinkDeny.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Config } from '@oclif/core';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+import { PackageTrustLink, PackageTrustLinkDenyResult } from '@salesforce/packaging';
+import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { PackageTrustLinkDenyCommand } from '../../../src/commands/package/trust/link/deny.js';
+
+const requestId = '2vtxx0000000001AAA';
+const authoringOrgId = '00Dxx0000009zZZEAY';
+const denyResult: PackageTrustLinkDenyResult = {
+  LinkRequestId: requestId,
+  AuthoringOrgId: authoringOrgId,
+  VerifiedOrgId: '00Dxx0000001gPLEAY',
+  Status: 'Declined',
+};
+
+describe('package:trust:link:deny - tests', () => {
+  const $$ = new TestContext();
+  const testOrg = new MockTestOrgData();
+  const config = new Config({ root: import.meta.url });
+  let denyStub: sinon.SinonStub;
+  let sfCommandStubs: ReturnType<typeof stubSfCommandUx>;
+
+  beforeEach(async () => {
+    await $$.stubAuths(testOrg);
+    await config.load();
+    denyStub = $$.SANDBOX.stub(PackageTrustLink, 'deny').resolves(denyResult);
+    sfCommandStubs = stubSfCommandUx($$.SANDBOX);
+  });
+
+  afterEach(() => {
+    $$.restore();
+  });
+
+  it('denies a trust link selected by request ID', async () => {
+    const command = new PackageTrustLinkDenyCommand(
+      ['--request', requestId, '--target-org', testOrg.username, '--api-version', '68.0'],
+      config
+    );
+
+    const result = await command.run();
+
+    expect(result).to.deep.equal(denyResult);
+    expect(denyStub.firstCall.args[1]).to.deep.equal({ requestId });
+    expect(sfCommandStubs.log.firstCall.args[0]).to.contain(requestId);
+  });
+
+  it('denies a trust link selected by authoring org', async () => {
+    const command = new PackageTrustLinkDenyCommand(
+      ['--authoring-org', authoringOrgId, '--target-org', testOrg.username],
+      config
+    );
+
+    await command.run();
+
+    expect(denyStub.firstCall.args[1]).to.deep.equal({ authoringOrgId });
+  });
+
+  it('requires a selector', async () => {
+    const command = new PackageTrustLinkDenyCommand(['--target-org', testOrg.username], config);
+    try {
+      await command.run();
+      expect.fail('expected exactly-one flag validation to fail');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+    }
+    expect(denyStub.called).to.equal(false);
+  });
+
+  it('rejects multiple selectors', async () => {
+    const command = new PackageTrustLinkDenyCommand(
+      ['--request', requestId, '--authoring-org', authoringOrgId, '--target-org', testOrg.username],
+      config
+    );
+    try {
+      await command.run();
+      expect.fail('expected exactly-one flag validation to fail');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+    }
+    expect(denyStub.called).to.equal(false);
+  });
+
+  it('rejects an invalid authoring org ID before calling the library', async () => {
+    const command = new PackageTrustLinkDenyCommand(
+      ['--authoring-org', 'not-an-org', '--target-org', testOrg.username],
+      config
+    );
+
+    try {
+      await command.run();
+      expect.fail('expected invalid org ID validation to fail');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+    }
+    expect(denyStub.called).to.equal(false);
+  });
+
+  it('rejects a request ID with the wrong entity prefix before calling the library', async () => {
+    const command = new PackageTrustLinkDenyCommand(
+      ['--request', authoringOrgId, '--target-org', testOrg.username],
+      config
+    );
+
+    try {
+      await command.run();
+      expect.fail('expected invalid request ID validation to fail');
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+    }
+    expect(denyStub.called).to.equal(false);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1368,10 +1368,10 @@
   dependencies:
     "@salesforce/ts-types" "^3.0.0"
 
-"@salesforce/packaging@5.0.9-spi.4":
-  version "5.0.9-spi.4"
-  resolved "https://registry.npmjs.org/@salesforce/packaging/-/packaging-5.0.9-spi.4.tgz#1e57e6fe03ddfb45d285f4273eb02326c306bd9c"
-  integrity sha512-6G/47Hn4QYpfPn1vljDqt/UIntAdW40cQ1OxClAegJK5K5PH+n/2/Ng6skTDpnF0gIOBMxZOzKQZOwCvY3KkLg==
+"@salesforce/packaging@5.0.9-spi.5":
+  version "5.0.9-spi.5"
+  resolved "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@salesforce/packaging/-/packaging-5.0.9-spi.5.tgz#7a99dcb0d09f313ec6ae3707057f1e8a7c9c1504"
+  integrity sha512-BRbCnlZGhRLK5KAu+um+azP/2c+UhIt9PU/iyJfgFVTJ2HPzlHhIWXMfwtAXEa+Lxlpxvkk5rswZGth7+9W2ZQ==
   dependencies:
     "@jsforce/jsforce-node" "^3.10.19"
     "@salesforce/core" "^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1370,7 +1370,7 @@
 
 "@salesforce/packaging@5.0.9-spi.5":
   version "5.0.9-spi.5"
-  resolved "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@salesforce/packaging/-/packaging-5.0.9-spi.5.tgz#7a99dcb0d09f313ec6ae3707057f1e8a7c9c1504"
+  resolved "https://registry.npmjs.org/@salesforce/packaging/-/packaging-5.0.9-spi.5.tgz#7a99dcb0d09f313ec6ae3707057f1e8a7c9c1504"
   integrity sha512-BRbCnlZGhRLK5KAu+um+azP/2c+UhIt9PU/iyJfgFVTJ2HPzlHhIWXMfwtAXEa+Lxlpxvkk5rswZGth7+9W2ZQ==
   dependencies:
     "@jsforce/jsforce-node" "^3.10.19"


### PR DESCRIPTION
## Summary
- add beta `sf package trust link deny` for verified PBO admins
- require exactly one of `--request <2vt...>` or `--authoring-org <00D...>` and delegate to `PackageTrustLink.deny`
- decline pending VerifiedDev requests (Tooling `Status = Declined`); JSON schema and command snapshot coverage

Library: [forcedotcom/packaging#922](https://github.com/forcedotcom/packaging/pull/922). Plugin CI needs that library on npm (next `5.0.9-spi.*` after [packaging#921](https://github.com/forcedotcom/packaging/pull/921) / `5.0.9-spi.4`) before the pin can be bumped the way approve used `5.0.9-spi.4`.

Also stacks on [plugin-packaging#1277](https://github.com/salesforcecli/plugin-packaging/pull/1277) (approve command). Extra approve commits drop out once that PR merges.

## Test plan
- [x] `yarn mocha test/commands/package/packageTrustLinkDeny.test.ts`
- [x] request-ID and authoring-org selector unit tests
- [x] missing, conflicting, and wrong-prefix selector validation
- [ ] bump `@salesforce/packaging` to the published SPI build that includes `deny`