### PR TITLE
@W-22247284@ feat: add --distribution-type flag to package create and update

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -254,6 +254,7 @@
     "flags": [
       "api-version",
       "description",
+      "distribution-type",
       "error-notification-username",
       "flags-dir",
       "json",
@@ -463,6 +464,7 @@
     "flags": [
       "api-version",
       "description",
+      "distribution-type",
       "enable-app-analytics",
       "error-notification-username",
       "flags-dir",

--- a/messages/package_create.md
+++ b/messages/package_create.md
@@ -65,3 +65,11 @@ The options for package type are Managed and Unlocked (Managed=DeveloperManagedS
 # flags.path.summary
 
 Path to directory that contains the contents of the package.
+
+# flags.distribution-type.summary
+
+Distribution type of the package.
+
+# flags.distribution-type.description
+
+Controls how the package is distributed. Valid values from the CLI are PublicSecure and Limited. If you don't specify a distribution type, the server defaults it based on the package type. Available in API version 68.0 and later.

--- a/messages/package_update.md
+++ b/messages/package_update.md
@@ -49,3 +49,11 @@ Specify the recommended package version for subscribers to install. If a subscri
 # flags.skip-ancestor-check.summary
 
 Bypass the ancestry check for setting a recommended version.
+
+# flags.distribution-type.summary
+
+New distribution type of the package.
+
+# flags.distribution-type.description
+
+Controls how the package is distributed. Valid values from the CLI are PublicSecure and Limited. Available in API version 68.0 and later.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@oclif/core": "^4",
     "@salesforce/core": "^9.1.0",
     "@salesforce/kit": "^4.0.0",
-    "@salesforce/packaging": "5.0.9-spi.6",
+    "@salesforce/packaging": "5.0.9-spi.7",
     "@salesforce/sf-plugins-core": "^13.0.0",
     "@salesforce/ts-types": "^3.0.1",
     "chalk": "^5.6.2"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@oclif/core": "^4",
     "@salesforce/core": "^9.1.0",
     "@salesforce/kit": "^4.0.0",
-    "@salesforce/packaging": "5.0.9-spi.5",
+    "@salesforce/packaging": "5.0.9-spi.6",
     "@salesforce/sf-plugins-core": "^13.0.0",
     "@salesforce/ts-types": "^3.0.1",
     "chalk": "^5.6.2"

--- a/schemas/package-list.json
+++ b/schemas/package-list.json
@@ -59,8 +59,8 @@
     },
     "DistributionType": {
       "type": "string",
-      "enum": ["Public", "PublicSecure", "Limited", "Private"],
-      "description": "The distribution type of a package, controlling install-time security.\n\nThe Tooling API `Package2.DistributionType` field can hold any of these values, but only `PublicSecure` and `Limited` may be set from the CLI on create/update — `Public` and `Private` are backend-only states (`Public` is the legacy default the backend assigns; `Private` is not yet selectable). See  {@link  SettableDistributionType }  for the CLI-settable subset."
+      "enum": ["Public", "PublicSecure", "Limited"],
+      "description": "The distribution type of a package, controlling install-time security.\n\nThe Tooling API `Package2.DistributionType` field can hold any of these values, but only `PublicSecure` and `Limited` may be set from the CLI on create/update — `Public` is a backend-only state (the legacy default the backend assigns). See  {@link  SettableDistributionType }  for the CLI-settable subset."
     }
   }
 }

--- a/schemas/package-list.json
+++ b/schemas/package-list.json
@@ -33,6 +33,9 @@
         "AppAnalyticsEnabled": {
           "type": "boolean"
         },
+        "DistributionType": {
+          "$ref": "#/definitions/DistributionType"
+        },
         "Alias": {
           "type": "string"
         },
@@ -53,6 +56,11 @@
     "PackageType": {
       "type": "string",
       "enum": ["Managed", "Unlocked"]
+    },
+    "DistributionType": {
+      "type": "string",
+      "enum": ["Public", "PublicSecure", "Limited", "Private"],
+      "description": "The distribution type of a package, controlling install-time security.\n\nThe Tooling API `Package2.DistributionType` field can hold any of these values, but only `PublicSecure` and `Limited` may be set from the CLI on create/update — `Public` and `Private` are backend-only states (`Public` is the legacy default the backend assigns; `Private` is not yet selectable). See  {@link  SettableDistributionType }  for the CLI-settable subset."
     }
   }
 }

--- a/schemas/package-version-report.json
+++ b/schemas/package-version-report.json
@@ -73,6 +73,9 @@
             "RecommendedVersionId": {
               "type": "string"
             },
+            "DistributionType": {
+              "$ref": "#/definitions/DistributionType"
+            },
             "IsOrgDependent": {
               "type": "string"
             }
@@ -230,6 +233,11 @@
     "PackageType": {
       "type": "string",
       "enum": ["Managed", "Unlocked"]
+    },
+    "DistributionType": {
+      "type": "string",
+      "enum": ["Public", "PublicSecure", "Limited", "Private"],
+      "description": "The distribution type of a package, controlling install-time security.\n\nThe Tooling API `Package2.DistributionType` field can hold any of these values, but only `PublicSecure` and `Limited` may be set from the CLI on create/update — `Public` and `Private` are backend-only states (`Public` is the legacy default the backend assigns; `Private` is not yet selectable). See  {@link  SettableDistributionType }  for the CLI-settable subset."
     },
     "CodeCoveragePercentages": {
       "anyOf": [

--- a/schemas/package-version-report.json
+++ b/schemas/package-version-report.json
@@ -236,8 +236,8 @@
     },
     "DistributionType": {
       "type": "string",
-      "enum": ["Public", "PublicSecure", "Limited", "Private"],
-      "description": "The distribution type of a package, controlling install-time security.\n\nThe Tooling API `Package2.DistributionType` field can hold any of these values, but only `PublicSecure` and `Limited` may be set from the CLI on create/update — `Public` and `Private` are backend-only states (`Public` is the legacy default the backend assigns; `Private` is not yet selectable). See  {@link  SettableDistributionType }  for the CLI-settable subset."
+      "enum": ["Public", "PublicSecure", "Limited"],
+      "description": "The distribution type of a package, controlling install-time security.\n\nThe Tooling API `Package2.DistributionType` field can hold any of these values, but only `PublicSecure` and `Limited` may be set from the CLI on create/update — `Public` is a backend-only state (the legacy default the backend assigns). See  {@link  SettableDistributionType }  for the CLI-settable subset."
     },
     "CodeCoveragePercentages": {
       "anyOf": [

--- a/src/commands/package/create.ts
+++ b/src/commands/package/create.ts
@@ -16,7 +16,7 @@
 
 import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core/messages';
-import { Package, PackageCreateOptions, PackageType } from '@salesforce/packaging';
+import { Package, PackageCreateOptions, PackageType, SettableDistributionType } from '@salesforce/packaging';
 import { requiredHubFlag } from '../../utils/hubFlag.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
@@ -78,6 +78,12 @@ export class PackageCreateCommand extends SfCommand<PackageCreate> {
       summary: messages.getMessage('flags.error-notification-username.summary'),
       description: messages.getMessage('flags.error-notification-username.description'),
     }),
+    'distribution-type': Flags.custom<SettableDistributionType>({
+      options: ['PublicSecure', 'Limited'],
+    })({
+      summary: messages.getMessage('flags.distribution-type.summary'),
+      description: messages.getMessage('flags.distribution-type.description'),
+    }),
   };
 
   public async run(): Promise<PackageCreate> {
@@ -90,6 +96,7 @@ export class PackageCreateCommand extends SfCommand<PackageCreate> {
       orgDependent: flags['org-dependent'],
       packageType: flags['package-type'],
       path: flags.path,
+      distributionType: flags['distribution-type'],
     };
     const result: PackageCreate = await Package.create(
       flags['target-dev-hub'].getConnection(flags['api-version']),

--- a/src/commands/package/list.ts
+++ b/src/commands/package/list.ts
@@ -35,6 +35,7 @@ export type Package2Result = Required<Pick<PackagingSObjects.Package2, 'Id' | 'N
       | 'ConvertedFromPackageId'
       | 'PackageErrorUsername'
       | 'AppAnalyticsEnabled'
+      | 'DistributionType'
     > & {
       Alias: string;
       CreatedBy: string;
@@ -84,6 +85,7 @@ export class PackageListCommand extends SfCommand<PackageListCommandResult> {
             'Error Notification Username': r.PackageErrorUsername,
             'Created By': r.CreatedBy,
             ...(parseInt(apiVersion, 10) >= 59 ? { 'App Analytics Enabled': r.AppAnalyticsEnabled } : {}),
+            ...(parseInt(apiVersion, 10) >= 68 ? { 'Distribution Type': r.DistributionType } : {}),
           }
         : {}),
     }));
@@ -106,6 +108,7 @@ const mapRecordsToResults = (records: PackagingSObjects.Package2[], project?: Sf
         IsOrgDependent,
         PackageErrorUsername,
         AppAnalyticsEnabled,
+        DistributionType,
         CreatedById,
       }) => ({
         Id,
@@ -119,6 +122,7 @@ const mapRecordsToResults = (records: PackagingSObjects.Package2[], project?: Sf
         IsOrgDependent: ContainerOptions === 'Managed' ? 'N/A' : IsOrgDependent ? 'Yes' : 'No',
         PackageErrorUsername,
         AppAnalyticsEnabled,
+        DistributionType,
         CreatedBy: CreatedById,
       })
     );

--- a/src/commands/package/update.ts
+++ b/src/commands/package/update.ts
@@ -16,7 +16,7 @@
 
 import { Flags, loglevel, orgApiVersionFlagWithDeprecations, SfCommand } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core/messages';
-import { Package, PackageSaveResult } from '@salesforce/packaging';
+import { Package, PackageSaveResult, SettableDistributionType } from '@salesforce/packaging';
 import { requiredHubFlag } from '../../utils/hubFlag.js';
 import { maybeGetProject } from '../../utils/getProject.js';
 
@@ -66,6 +66,12 @@ export class PackageUpdateCommand extends SfCommand<PackageSaveResult> {
     'skip-ancestor-check': Flags.boolean({
       summary: messages.getMessage('flags.skip-ancestor-check.summary'),
     }),
+    'distribution-type': Flags.custom<SettableDistributionType>({
+      options: ['PublicSecure', 'Limited'],
+    })({
+      summary: messages.getMessage('flags.distribution-type.summary'),
+      description: messages.getMessage('flags.distribution-type.description'),
+    }),
   };
 
   public async run(): Promise<PackageSaveResult> {
@@ -85,6 +91,7 @@ export class PackageUpdateCommand extends SfCommand<PackageSaveResult> {
         PackageErrorUsername: flags['error-notification-username'],
         AppAnalyticsEnabled: flags['enable-app-analytics'],
         RecommendedVersionId: flags['recommended-version-id'],
+        DistributionType: flags['distribution-type'],
       },
       flags['skip-ancestor-check']
     );

--- a/test/commands/package/packageCreate.test.ts
+++ b/test/commands/package/packageCreate.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from 'chai';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+import { Config } from '@oclif/core';
+import { Package, PackageCreateOptions } from '@salesforce/packaging';
+import sinon from 'sinon';
+import { PackageCreateCommand } from '../../../src/commands/package/create.js';
+
+describe('package:create', () => {
+  const $$ = new TestContext();
+  const testOrg = new MockTestOrgData();
+  const config = new Config({ root: import.meta.url });
+
+  let createStub: sinon.SinonStub;
+
+  before(async () => {
+    await $$.stubAuths(testOrg);
+    await config.load();
+  });
+
+  beforeEach(() => {
+    $$.SANDBOX.stub(PackageCreateCommand.prototype, 'table');
+    createStub = $$.SANDBOX.stub(Package, 'create').resolves({ Id: '0Ho000000000001AAA' });
+  });
+
+  afterEach(() => {
+    $$.restore();
+    $$.SANDBOX.restore();
+  });
+
+  it('passes the distribution type through to the library when provided', async () => {
+    const cmd = new PackageCreateCommand(
+      [
+        '--name',
+        'MyPkg',
+        '--package-type',
+        'Managed',
+        '--path',
+        'force-app',
+        '--distribution-type',
+        'Limited',
+        '-v',
+        testOrg.username,
+      ],
+      config
+    );
+    await cmd.run();
+    const options = createStub.getCall(0).args[2] as PackageCreateOptions;
+    expect(options.distributionType).to.equal('Limited');
+  });
+
+  it('leaves the distribution type undefined when the flag is omitted', async () => {
+    const cmd = new PackageCreateCommand(
+      ['--name', 'MyPkg', '--package-type', 'Managed', '--path', 'force-app', '-v', testOrg.username],
+      config
+    );
+    await cmd.run();
+    const options = createStub.getCall(0).args[2] as PackageCreateOptions;
+    expect(options.distributionType).to.equal(undefined);
+  });
+
+  it('rejects a distribution type that is not CLI-settable', async () => {
+    try {
+      const cmd = new PackageCreateCommand(
+        [
+          '--name',
+          'MyPkg',
+          '--package-type',
+          'Managed',
+          '--path',
+          'force-app',
+          '--distribution-type',
+          'Public',
+          '-v',
+          testOrg.username,
+        ],
+        config
+      );
+      await cmd.run();
+      expect.fail('Expected an invalid-flag-value error');
+    } catch (e) {
+      expect((e as Error).message).to.include('PublicSecure').and.to.include('Limited');
+      expect(createStub.called).to.equal(false);
+    }
+  });
+});

--- a/test/commands/package/packageUpdate.test.ts
+++ b/test/commands/package/packageUpdate.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from 'chai';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+import { Config } from '@oclif/core';
+import { Package, PackageUpdateOptions } from '@salesforce/packaging';
+import sinon from 'sinon';
+import { SfCommand } from '@salesforce/sf-plugins-core';
+import { PackageUpdateCommand } from '../../../src/commands/package/update.js';
+
+describe('package:update', () => {
+  const $$ = new TestContext();
+  const testOrg = new MockTestOrgData();
+  const config = new Config({ root: import.meta.url });
+
+  const pkgId = '0Ho000000000001AAA';
+  let updateStub: sinon.SinonStub;
+
+  before(async () => {
+    await $$.stubAuths(testOrg);
+    await config.load();
+  });
+
+  beforeEach(() => {
+    $$.SANDBOX.stub(SfCommand.prototype, 'logSuccess');
+    // The Package class is tested in the packaging library; stub the public API the command uses.
+    // A raw 0Ho id skips project alias resolution in the constructor, so only these need stubbing.
+    $$.SANDBOX.stub(Package.prototype, 'getId').returns(pkgId);
+    updateStub = $$.SANDBOX.stub(Package.prototype, 'update').resolves({ success: true, id: pkgId, errors: [] });
+  });
+
+  afterEach(() => {
+    $$.restore();
+    $$.SANDBOX.restore();
+  });
+
+  it('passes the distribution type through to the library when provided', async () => {
+    const cmd = new PackageUpdateCommand(
+      ['--package', pkgId, '--distribution-type', 'PublicSecure', '-v', testOrg.username],
+      config
+    );
+    await cmd.run();
+    const options = updateStub.getCall(0).args[0] as PackageUpdateOptions;
+    expect(options.DistributionType).to.equal('PublicSecure');
+  });
+
+  it('leaves the distribution type undefined when the flag is omitted', async () => {
+    const cmd = new PackageUpdateCommand(['--package', pkgId, '--name', 'NewName', '-v', testOrg.username], config);
+    await cmd.run();
+    const options = updateStub.getCall(0).args[0] as PackageUpdateOptions;
+    expect(options.DistributionType).to.equal(undefined);
+  });
+
+  it('rejects a distribution type that is not CLI-settable', async () => {
+    try {
+      const cmd = new PackageUpdateCommand(
+        ['--package', pkgId, '--distribution-type', 'Public', '-v', testOrg.username],
+        config
+      );
+      await cmd.run();
+      expect.fail('Expected an invalid-flag-value error');
+    } catch (e) {
+      expect((e as Error).message).to.include('PublicSecure').and.to.include('Limited');
+      expect(updateStub.called).to.equal(false);
+    }
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1368,10 +1368,10 @@
   dependencies:
     "@salesforce/ts-types" "^3.0.0"
 
-"@salesforce/packaging@5.0.9-spi.6":
-  version "5.0.9-spi.6"
-  resolved "https://registry.npmjs.org/@salesforce/packaging/-/packaging-5.0.9-spi.6.tgz#b6e5dd1ead1d6a77b97736cfe9aa9642ee633661"
-  integrity sha512-KxTHXHnF2LX9VS/VhmF/XOQP/bPxoZsVV9v7MxypFYzSGVUgcJIYHh3Vsfn5bvLZk5Jde63TssVD3bahvwrtbA==
+"@salesforce/packaging@5.0.9-spi.7":
+  version "5.0.9-spi.7"
+  resolved "https://registry.npmjs.org/@salesforce/packaging/-/packaging-5.0.9-spi.7.tgz#1bff807245fd202ca2b87852a23c58cf72b321a0"
+  integrity sha512-wXNj1ym06Ok/I2OjTvQcTeDc8xDMVIS2FEt8nC9Im6cc70u1JB1FKHon1dsY+r5S1BjSn985A/fShbUFN7zYfA==
   dependencies:
     "@jsforce/jsforce-node" "^3.10.19"
     "@salesforce/core" "^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1368,10 +1368,10 @@
   dependencies:
     "@salesforce/ts-types" "^3.0.0"
 
-"@salesforce/packaging@5.0.9-spi.5":
-  version "5.0.9-spi.5"
-  resolved "https://registry.npmjs.org/@salesforce/packaging/-/packaging-5.0.9-spi.5.tgz#7a99dcb0d09f313ec6ae3707057f1e8a7c9c1504"
-  integrity sha512-BRbCnlZGhRLK5KAu+um+azP/2c+UhIt9PU/iyJfgFVTJ2HPzlHhIWXMfwtAXEa+Lxlpxvkk5rswZGth7+9W2ZQ==
+"@salesforce/packaging@5.0.9-spi.6":
+  version "5.0.9-spi.6"
+  resolved "https://registry.npmjs.org/@salesforce/packaging/-/packaging-5.0.9-spi.6.tgz#b6e5dd1ead1d6a77b97736cfe9aa9642ee633661"
+  integrity sha512-KxTHXHnF2LX9VS/VhmF/XOQP/bPxoZsVV9v7MxypFYzSGVUgcJIYHh3Vsfn5bvLZk5Jde63TssVD3bahvwrtbA==
   dependencies:
     "@jsforce/jsforce-node" "^3.10.19"
     "@salesforce/core" "^9.0.0"


### PR DESCRIPTION
## What & why

Adds an optional `--distribution-type` flag to `sf package create` and `sf package update`, and surfaces the distribution type in `sf package list` (W-22247284).

This is the **plugin** half of the feature. The business logic, validation, and types live in `@salesforce/packaging`; this PR pins the prerelease that ships them (`5.0.9-spi.6`) and wires up the command surface.

Library PR: forcedotcom/packaging#926

## Behavior

- `--distribution-type` accepts **`PublicSecure` or `Limited` only** (oclif enum). `Public` and `Private` are backend-only states and are rejected.
- **Optional on create** — when omitted, the backend defaults the distribution type based on the package type.
- **Gated at API version 68.0** by the library; supplying it against an older API version errors.
- `package list --verbose` shows a **Distribution Type** column at API 68.0+.

## Changes

- `--distribution-type` flag on `package create` and `package update` (`Flags.custom<SettableDistributionType>({ options: ['PublicSecure', 'Limited'] })`), wired into their options.
- `DistributionType` added to `package list`'s `Package2Result`, record mapping, and verbose display column.
- Flag messages in `package_create.md` / `package_update.md`.
- `command-snapshot.json` entries for create + update; schemas updated (`package-list.json`, `package-version-report.json`).
- Unit tests asserting flag passthrough, omission, and invalid-value rejection for both commands.
- Pin `@salesforce/packaging` to `5.0.9-spi.6`.

## Validation

- `yarn build` clean against the published `5.0.9-spi.6` (unlinked, real package).
- 176 unit tests passing (incl. 6 new).
- `snapshot:compare` and `schema:compare` both report "No changes have been detected."

🤖 Generated with [Claude Code](https://claude.com/claude-code)